### PR TITLE
Harden Scripture parsing and repository access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: librarian-codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cf463419fdde78c727231e445622a9ac37966f84
+        with:
+          languages: python
+      - name: Analyze
+        uses: github/codeql-action/analyze@cf463419fdde78c727231e445622a9ac37966f84

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -1,73 +1,60 @@
-name: Build, Test and Deploy getBible Librarian
+name: Publish package
 
 on:
   push:
-    branches: [ master ]
+    tags: ["v*"]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # 3.7 is EOL and often fails on ubuntu-latest. Test on supported versions.
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-            requirements-test.txt
-
-      - name: Upgrade build tooling
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install dependencies
+          python-version: "3.12"
+      - name: Build and validate
         run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pip install build==1.2.2.post1 twine==6.1.0
+          python -m build
+          twine check dist/*
+      - name: Test built wheel
+        run: |
+          python -m pip install dist/*.whl
+          python -m unittest discover -s tests -v
+      - name: Store distributions
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: distributions
+          path: dist/
+          if-no-files-found: error
 
-      - name: Install the package (editable)
-        run: pip install -e .
-
-      - name: Run unittests
-        run: python -m unittest discover -s tests -v
-
-  deploy:
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build-and-test
     runs-on: ubuntu-latest
-    # Only deploy on direct pushes to master (not PRs)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-
+    timeout-minutes: 10
+    environment: pypi
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
-          python-version: '3.12'
-          cache: pip
-
-      - name: Upgrade build tooling
-        run: python -m pip install --upgrade pip setuptools wheel build twine
-
-      - name: Build Package
-        run: python -m build
-
-      - name: Publish to PyPI
+          name: distributions
+          path: dist/
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - name: Publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
-
+        run: |
+          python -m pip install twine==6.1.0
+          twine upload --non-interactive dist/*

--- a/.github/workflows/stable-librarian.yml
+++ b/.github/workflows/stable-librarian.yml
@@ -1,47 +1,78 @@
 name: Stable Librarian
 
 on:
-  push:
-    branches: [ staging ]
   pull_request:
-    branches: [ master, staging ]
-  workflow_dispatch:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: librarian-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          # Cache keys will include any of these files if present
+          cache: pip
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
-            requirements-test.txt
-
-      - name: Upgrade build tooling
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install dependencies
+      - name: Install
         run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Install the package (editable)
-        run: pip install -e .
-
-      - name: Run unittests
+          python -m pip install --disable-pip-version-check -r requirements.txt
+          python -m pip install --no-deps -e .
+      - name: Unit and hardening tests
         run: python -m unittest discover -s tests -v
 
+  quality-and-security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install checks
+        run: python -m pip install -r requirements.txt -r requirements-dev.txt
+      - name: Ruff
+        run: |
+          ruff check \
+            src/getbible/__init__.py \
+            src/getbible/errors.py \
+            src/getbible/getbible.py \
+            src/getbible/getbible_book_number.py \
+            src/getbible/getbible_reference.py \
+            tests/test_getbible.py \
+            tests/test_getbible_reference.py \
+            tests/test_hardening.py
+      - name: Bandit
+        run: bandit -q -r src/getbible
+      - name: Dependency audit
+        run: pip-audit -r requirements.txt
+      - name: Token pattern scan
+        shell: bash
+        run: |
+          if git grep -nE '[0-9]{8,12}:[A-Za-z0-9_-]{30,}' -- ':!tests'; then
+            echo 'A value resembling a Telegram bot token was found.' >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,152 +1,107 @@
-# getBible Librarian
+# GetBible Librarian
 
 [![Stable Librarian](https://github.com/getbible/librarian/actions/workflows/stable-librarian.yml/badge.svg)](https://github.com/getbible/librarian/actions/workflows/stable-librarian.yml)
-[![GetBible Librarian](https://img.shields.io/pypi/v/getbible?style=flat-square)](https://pypi.org/project/getbible/)
+[![PyPI](https://img.shields.io/pypi/v/getbible?style=flat-square)](https://pypi.org/project/getbible/)
 
-The `getBible` Librarian package is a Python library designed for efficiently retrieving the scripture reference across various translations.
+`getbible` retrieves Scripture from a GetBible v2 repository and parses localized Bible references. Version 1.2 adds strict input validation, bounded work, typed failures, explicit network timeouts and retries, and bounded thread-safe caches.
 
 ## Installation
 
 ```bash
-pip install getbible
+python -m pip install getbible
 ```
-> see package on [pypi](https://pypi.org/project/getbible)
 
-## Features
+Python 3.9 or newer is required.
 
-### Get Scripture
+## Basic use
 
 ```python
-import json
 from getbible import GetBible
 
-# Initialize the class
-getbible = GetBible()
-
-# Get the scripture as JSON
-scripture_json = getbible.scripture("Genesis 1:1")
-print(scripture_json)  # Outputs the JSON scripture as a string.
-
-# Get the scripture as dictionary
-scripture_dict = getbible.select("Genesis 1:1")
-print(json.dumps(scripture_dict, indent=4))  # Pretty-prints the dictionary.
+with GetBible() as scriptures:
+    result = scriptures.select("John 3:16", "kjv")
+    print(result)
 ```
 
-#### Using Translation Abbreviations
-
-When utilizing the `GetBible` class to look up a reference, you can use the lowercase abbreviations of the target translation:
+Multiple references are separated with semicolons:
 
 ```python
-import json
-from getbible import GetBible
-
-# Initialize the class
-getbible = GetBible()
-
-scripture = getbible.select("Genesis 1:1-5", 'aov')
-print(json.dumps(scripture, indent=4))  # Pretty-prints the dictionary.
+result = scriptures.select("Genesis 1:1-3;John 1:1", "kjv")
 ```
 
-In this code snippet, `"aov"` is used as the abbreviation for the Afrikaans Ou Vertaaling.
-
-### Get Reference
+The default safety budget is eight references and 200 selected verses per request. These limits are configurable, but callers exposed to untrusted input should normally reduce them rather than increase them.
 
 ```python
-from getbible import GetBibleReference
-
-# Initialize the class
-get = GetBibleReference()
-
-# Find well form reference
-reference = get.ref("Genesis 1:1-5")
-print(reference)  # Outputs the dataclass [BookReference] { book: int, chapter: int, verses: list }
+scriptures = GetBible(
+    max_references=8,
+    max_total_verses=100,
+    connect_timeout=3.05,
+    read_timeout=10.0,
+    retries=2,
+)
 ```
 
-#### Using Translation Abbreviations
+## Local repository
 
-When utilizing the `GetBibleReference` class to look up a reference, you can use the lowercase abbreviations of the target translation:
+A local GetBible v2 data tree removes the network dependency:
 
 ```python
-from getbible import GetBibleReference
-
-# Initialize the class
-get = GetBibleReference()
-
-reference = get.ref("Genesis 1:1-5", 'kjv')
+scriptures = GetBible(repo_path="/srv/getbible-data", version="v2")
 ```
 
-In this code snippet, `"kjv"` is used as the abbreviation for the King James Version to speedup the search.
+`repo_path` must contain paths such as `v2/kjv/books.json` and `v2/kjv/43/3.json`.
 
-### Get Book Number
+## Validation
+
+Reference parsing consumes the complete input. Malformed suffixes, dangling ranges, reversed ranges, excessive ranges, control characters, and unknown books are rejected rather than silently converted to another verse.
 
 ```python
-from getbible import GetBibleBookNumber
+from getbible import GetBibleReference, InvalidReferenceError
 
-# Initialize the class
-get_book = GetBibleBookNumber()
+parser = GetBibleReference(max_verses=100)
 
-# Find a book number
-book_number = get_book.number("Genesis")
-print(book_number)  # Outputs the book number of "Genesis" = 1
+try:
+    reference = parser.ref("1 John 3:16,19-21", "kjv")
+except InvalidReferenceError as error:
+    print(error)
 ```
 
-#### Available Translations and Abbreviations
+`GetBible.available_translations` returns the locally known translation codes without performing network I/O. `valid_translation()` first requires membership in that local set and only then checks the configured repository.
 
-The `GetBibleBookNumber` package supports a range of Bible translations, each identified by a lowercase abbreviation. These abbreviations and the corresponding translation data are stored in the `data` folder.
-
-#### Finding Translation Abbreviations
-
-To find the available translation abbreviations:
-
-1. Go to the `data` [directory in the package](https://git.vdm.dev/getBible/librarian/src/branch/master/src/getbible/data).
-2. Each JSON file in this directory corresponds to a different translation.
-3. The file name (without the `.json` extension) represents the abbreviation for that translation.
-
-For instance, if you find a file named `kjv.json`, then `kjv` is the abbreviation for the King James Version translation.
-
-#### Using Translation Abbreviations
-
-When utilizing the `GetBibleBookNumber` class to look up a book number, you should use these lowercase abbreviations:
+## Typed errors
 
 ```python
-book_number = get_book.number("Gen", "kjv", ["aov", "swahili"])
+from getbible import (
+    DataValidationError,
+    InvalidReferenceError,
+    ScriptureNotFoundError,
+    TranslationNotFoundError,
+    UpstreamUnavailableError,
+)
 ```
 
-In this code snippet, `"kjv"` is used as the abbreviation for the King James Version, `"aov"` for the Afrikaans Ou Vertaaling, and `"swahili"` for the Swahili Version.
+Applications should convert these exceptions into their own user-safe messages. Do not expose raw exception details from unexpected failures to public users.
 
-## Source Installation (git)
-
-To install `getBible` Librarian, you need to clone the repository and install the package manually. Ensure you have Python 3.7 or higher installed.
+## Development
 
 ```bash
-git clone https://git.vdm.dev/getBible/librarian.git
+git clone https://github.com/getbible/librarian.git
 cd librarian
-pip install .
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e . -r requirements-dev.txt
+python -m unittest discover -s tests -v
+ruff check src tests
+bandit -q -r src/getbible
+pip-audit -r requirements.txt
 ```
 
-## Development and Testing
+The default test suite is offline and deterministic. Network integration checks should be run separately against a controlled GetBible endpoint.
 
-To contribute or run tests, clone the repository and set up a virtual environment:
+## Security
 
-```bash
-git clone https://git.vdm.dev/getBible/librarian.git
-cd librarian
-python -m venv venv
-source venv/bin/activate  # On Windows use `venv\Scripts\activate`
-pip install -e .
-```
-
-Run tests using the standard unittest framework:
-
-```bash
-python -m unittest
-```
-
-## Contributing
-
-Contributions to the `getbible` Librarian package are welcome. Please ensure to follow the coding standards and write tests for new features.
+Please report vulnerabilities privately as described in [SECURITY.md](SECURITY.md). The parser and client have hard safety limits, but every public application must also apply user, chat, and global rate limits.
 
 ## License
 
-This project is licensed under the GNU GPL v2.0. See the LICENSE file for more details.
-
+GNU GPL v2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the latest released minor version. Older releases should be upgraded before reporting behavior that is already fixed in the current release.
+
+## Reporting a vulnerability
+
+Do not open a public issue for an unpatched vulnerability. Use GitHub's private vulnerability reporting feature for `getbible/librarian`, or contact the maintainers through the private address listed in the package metadata.
+
+Include the affected version or commit, a minimal reproduction, expected impact, and any suggested mitigation. Do not include real Telegram tokens, private user content, or credentials.
+
+## Security boundaries
+
+The library treats references and translation identifiers as untrusted. It applies strict parsing, hard request budgets, bounded caches, TLS verification, explicit network timeouts, and typed failures. Applications remain responsible for authentication, inbound rate limits, output escaping, privacy, and host-level resource limits.

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -1,0 +1,13 @@
+# Release gate
+
+A release is eligible only when all of the following are true:
+
+1. Unit and hardening tests pass on every supported Python version.
+2. The huge-range, malformed-suffix, reversed-range, translation-cache, timeout, invalid-JSON, and total-work regressions pass.
+3. Ruff, Bandit, dependency audit, and secret scan pass.
+4. The wheel and source distribution build successfully and `twine check` passes.
+5. The built wheel is installed into a clean environment and its offline test suite passes.
+6. The release commit is tagged intentionally and the protected `pypi` environment approves publication.
+7. A rollback is available by reinstalling the preceding package version.
+
+Production applications should additionally perform a concurrency test, upstream failure injection, a bounded-memory soak test, and a local-data fallback test before adopting a new release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
 [build-system]
 requires = ["setuptools>=65.5.1", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_ignores = true
+warn_redundant_casts = true
+check_untyped_defs = true
+no_implicit_optional = true
+
+[tool.bandit]
+exclude_dirs = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+bandit==1.8.3
+hypothesis==6.129.4
+mypy==1.15.0
+pip-audit==2.8.0
+ruff==0.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.31.0
+requests==2.32.5

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,33 @@
-from setuptools import setup, find_packages
+from pathlib import Path
 
-with open('README.md', 'r', encoding='utf-8') as f:
-    long_description = f.read()
+from setuptools import find_packages, setup
+
+
+long_description = Path("README.md").read_text(encoding="utf-8")
 
 setup(
     name="getbible",
-    version="1.1.2",
+    version="1.2.0",
     author="Llewellyn van der Merwe",
     author_email="getbible@vdm.io",
-    description="A Python package to retrieving Bible references with ease.",
+    description="Retrieve bounded, validated Bible references with ease.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url="https://git.vdm.dev/getBible/librarian",
+    long_description_content_type="text/markdown",
+    url="https://github.com/getbible/librarian",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     package_data={"getbible": ["data/*.json"]},
     include_package_data=True,
-    install_requires=[
-        "requests~=2.31.0"
-    ],
+    install_requires=["requests>=2.32.5,<3"],
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.9",
 )

--- a/src/getbible/__init__.py
+++ b/src/getbible/__init__.py
@@ -1,4 +1,24 @@
+from .errors import (
+    DataValidationError,
+    GetBibleError,
+    InvalidReferenceError,
+    ScriptureNotFoundError,
+    TranslationNotFoundError,
+    UpstreamUnavailableError,
+)
 from .getbible_book_number import GetBibleBookNumber
-from .getbible_reference import GetBibleReference
-from .getbible_reference import BookReference
+from .getbible_reference import BookReference, GetBibleReference
 from .getbible import GetBible
+
+__all__ = [
+    "BookReference",
+    "DataValidationError",
+    "GetBible",
+    "GetBibleBookNumber",
+    "GetBibleError",
+    "GetBibleReference",
+    "InvalidReferenceError",
+    "ScriptureNotFoundError",
+    "TranslationNotFoundError",
+    "UpstreamUnavailableError",
+]

--- a/src/getbible/errors.py
+++ b/src/getbible/errors.py
@@ -1,0 +1,25 @@
+"""Typed exceptions exposed by the GetBible client."""
+
+
+class GetBibleError(Exception):
+    """Base class for errors raised by the GetBible package."""
+
+
+class InvalidReferenceError(ValueError, GetBibleError):
+    """A Scripture reference is malformed, unsupported, or over its safety budget."""
+
+
+class TranslationNotFoundError(FileNotFoundError, GetBibleError):
+    """The requested translation is not available."""
+
+
+class ScriptureNotFoundError(ValueError, FileNotFoundError, GetBibleError):
+    """The requested chapter or verse does not exist."""
+
+
+class UpstreamUnavailableError(GetBibleError):
+    """The remote Scripture repository could not be reached safely."""
+
+
+class DataValidationError(GetBibleError):
+    """The Scripture repository returned malformed or unexpected data."""

--- a/src/getbible/getbible.py
+++ b/src/getbible/getbible.py
@@ -1,247 +1,337 @@
-import os
-import re
+"""Bounded and failure-aware access to the GetBible Scripture repository."""
+
+from collections import OrderedDict
 import json
-import requests
+import os
+from pathlib import Path
+import re
 import threading
 import time
-from datetime import datetime, timedelta
-from typing import Dict, Optional, Union
-from getbible import GetBibleReference
-from getbible import BookReference
+from typing import Any, Dict, Optional, Tuple, Union
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from getbible.errors import (
+    DataValidationError,
+    InvalidReferenceError,
+    ScriptureNotFoundError,
+    TranslationNotFoundError,
+    UpstreamUnavailableError,
+)
+from getbible.getbible_reference import BookReference, GetBibleReference
+
+
+_MISSING = object()
+
+
+class _TtlLruCache:
+    """Small thread-safe TTL/LRU cache with a hard entry limit."""
+
+    def __init__(self, max_size: int, ttl_seconds: float) -> None:
+        if max_size < 1 or ttl_seconds <= 0:
+            raise ValueError("Cache size and TTL must be positive.")
+        self._max_size = max_size
+        self._ttl_seconds = ttl_seconds
+        self._values = OrderedDict()
+        self._lock = threading.RLock()
+
+    def get(self, key: str) -> Any:
+        now = time.monotonic()
+        with self._lock:
+            item = self._values.get(key, _MISSING)
+            if item is _MISSING:
+                return _MISSING
+            created_at, value = item
+            if now - created_at >= self._ttl_seconds:
+                self._values.pop(key, None)
+                return _MISSING
+            self._values.move_to_end(key)
+            return value
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._values[key] = (time.monotonic(), value)
+            self._values.move_to_end(key)
+            while len(self._values) > self._max_size:
+                self._values.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._values.clear()
 
 
 class GetBible:
-    WORD_OPTIONS = {'allwords', 'anywords', 'exactwords'}
-    MATCH_OPTIONS = {'exactmatch', 'partialmatch'}
-    CASE_OPTIONS = {'caseinsensitive', 'casesensitive'}
-    TARGET_OPTIONS = {'allbooks', 'oldtestament', 'newtestament'} | set(map(str, range(1, 81)))
+    WORD_OPTIONS = {"allwords", "anywords", "exactwords"}
+    MATCH_OPTIONS = {"exactmatch", "partialmatch"}
+    CASE_OPTIONS = {"caseinsensitive", "casesensitive"}
+    TARGET_OPTIONS = {"allbooks", "oldtestament", "newtestament"} | set(
+        map(str, range(1, 84))
+    )
 
-    def __init__(self, repo_path: str = "https://api.getbible.net", version: str = 'v2') -> None:
-        """
-        Initialize the GetBible class.
+    _TRANSLATION_PATTERN = re.compile(r"[a-z0-9]{1,30}")
 
-        Sets up the class by initializing the cache, starting the background thread for
-        monthly cache reset, and other necessary setups.
+    def __init__(
+        self,
+        repo_path: str = "https://api.getbible.net",
+        version: str = "v2",
+        connect_timeout: float = 3.05,
+        read_timeout: float = 10.0,
+        retries: int = 2,
+        cache_size: int = 512,
+        cache_ttl_seconds: float = 3600.0,
+        negative_cache_ttl_seconds: float = 300.0,
+        max_references: int = 8,
+        max_total_verses: int = 200,
+        session: Optional[requests.Session] = None,
+        reference_parser: Optional[GetBibleReference] = None,
+    ) -> None:
+        if not isinstance(repo_path, str) or not repo_path.strip():
+            raise ValueError("repo_path must be a non-empty URL or filesystem path.")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError("version must be non-empty.")
+        if connect_timeout <= 0 or read_timeout <= 0:
+            raise ValueError("HTTP timeouts must be positive.")
+        if retries < 0 or max_references < 1 or max_total_verses < 1:
+            raise ValueError("Retry and request limits are invalid.")
 
-        :param repo_path: The repository path, which can be a URL or a local file path.
-        :param version: The version of the Bible repository.
-        """
-        self.__get = GetBibleReference()
-        self.__repo_path = repo_path
-        self.__repo_version = version
-        self.__books_cache = {}
-        self.__chapters_cache = {}
-        self.__start_cache_reset_thread()
-        # Pattern to check valid translations names
-        self.__pattern = re.compile(r'[a-zA-Z0-9]{1,30}')
-        # Determine if the repository path is a URL
-        self.__repo_path_url = self.__repo_path.startswith("http://") or self.__repo_path.startswith("https://")
+        self.__repo_path = repo_path.rstrip("/")
+        self.__repo_version = version.strip("/")
+        self.__repo_path_url = self.__repo_path.startswith(("http://", "https://"))
+        self.__timeout = (connect_timeout, read_timeout)  # type: Tuple[float, float]
+        self.__max_references = max_references
+        self.__max_total_verses = max_total_verses
+        self.__get = reference_parser or GetBibleReference(max_verses=max_total_verses)
+        self.__books_cache = _TtlLruCache(cache_size, cache_ttl_seconds)
+        self.__negative_books_cache = _TtlLruCache(cache_size, negative_cache_ttl_seconds)
+        self.__chapters_cache = _TtlLruCache(cache_size, cache_ttl_seconds)
+        self.__owns_session = session is None
+        self.__session = session or requests.Session()
 
-    def select(self, reference: str, abbreviation: Optional[str] = 'kjv') -> Dict[str, Union[Dict, str]]:
-        """
-        Select and return Bible verses based on the reference and abbreviation.
+        if self.__owns_session:
+            retry = Retry(
+                total=retries,
+                connect=retries,
+                read=retries,
+                status=retries,
+                backoff_factor=0.25,
+                status_forcelist=(429, 500, 502, 503, 504),
+                allowed_methods=frozenset({"GET"}),
+                respect_retry_after_header=True,
+                raise_on_status=False,
+            )
+            adapter = HTTPAdapter(
+                max_retries=retry,
+                pool_connections=min(cache_size, 32),
+                pool_maxsize=min(cache_size, 32),
+            )
+            self.__session.mount("https://", adapter)
+            self.__session.mount("http://", adapter)
+        self.__session.headers.setdefault("User-Agent", "getbible-librarian/1.2")
 
-        :param reference: The Bible reference (e.g., John 3:16).
-        :param abbreviation: The abbreviation for the Bible translation.
-        :return: dictionary of the selected Bible verses.
-        """
-        self.__check_translation(abbreviation)
-        result = {}
-        references = reference.split(';')
-        for ref in references:
-            try:
-                book_reference = self.__get.ref(ref, abbreviation)
-            except ValueError:
-                raise ValueError(f"Invalid reference '{ref}'.")
+    @property
+    def available_translations(self) -> frozenset:
+        """Translation codes known locally; reading this property performs no network I/O."""
+        return self.__get.available_translations
 
-            self.__set_verse(abbreviation, book_reference, result)
+    def select(
+        self, reference: str, abbreviation: Optional[str] = "kjv"
+    ) -> Dict[str, Union[Dict, str]]:
+        """Select Scripture while enforcing reference and total-work budgets."""
+        if not isinstance(reference, str):
+            raise InvalidReferenceError("Reference must be text.")
 
+        normalized_abbreviation = (abbreviation or "kjv").strip().casefold()
+        references = [item.strip() for item in reference.split(";")]
+        if not references or any(not item for item in references):
+            raise InvalidReferenceError("Every reference must be non-empty.")
+        if len(references) > self.__max_references:
+            raise InvalidReferenceError(
+                f"A request may contain at most {self.__max_references} references."
+            )
+
+        parsed_references = []
+        total_verses = 0
+        for raw_reference in references:
+            parsed = self.__get.ref(raw_reference, normalized_abbreviation)
+            total_verses += len(parsed.verses)
+            if total_verses > self.__max_total_verses:
+                raise InvalidReferenceError(
+                    f"A request may select at most {self.__max_total_verses} verses."
+                )
+            parsed_references.append(parsed)
+
+        self.__check_translation(normalized_abbreviation)
+        result = {}  # type: Dict[str, Union[Dict, str]]
+        for parsed in parsed_references:
+            self.__set_verse(normalized_abbreviation, parsed, result)
         return result
 
-    def scripture(self, reference: str, abbreviation: Optional[str] = 'kjv') -> str:
-        """
-        Select and return Bible verses based on the reference and abbreviation.
+    def scripture(self, reference: str, abbreviation: Optional[str] = "kjv") -> str:
+        return json.dumps(self.select(reference, abbreviation), ensure_ascii=False)
 
-        :param reference: The Bible reference (e.g., John 3:16).
-        :param abbreviation: The abbreviation for the Bible translation.
-        :return: JSON string of the selected Bible verses.
-        """
-
-        return json.dumps(self.select(reference, abbreviation))
-
-    def valid_reference(self, reference: str, abbreviation: Optional[str] = 'kjv') -> bool:
-        """
-        Validate a scripture reference and check its presence in the cache.
-
-        :param reference: Scripture reference string.
-        :param abbreviation: Optional translation code.
-        :return: True if valid and present, False otherwise.
-        """
+    def valid_reference(self, reference: str, abbreviation: Optional[str] = "kjv") -> bool:
         return self.__get.valid(reference, abbreviation)
 
     def valid_translation(self, abbreviation: str) -> bool:
-        """
-        Check if the given translation is valid.
+        """Validate only locally known codes, then confirm the configured repository has them."""
+        if not isinstance(abbreviation, str):
+            return False
+        normalized = abbreviation.strip().casefold()
+        if not self._TRANSLATION_PATTERN.fullmatch(normalized):
+            return False
+        if normalized not in self.available_translations:
+            return False
 
-        :param abbreviation: The abbreviation of the Bible translation to check.
-        :return: True if the translation is available, False otherwise.
-        """
-        if self.__pattern.match(abbreviation):
-            path = self.__generate_path(abbreviation, "books.json")
-            # Check if the translation is already in the cache
-            if abbreviation not in self.__books_cache:
-                self.__books_cache[abbreviation] = self.__fetch_data(path)
-            # Return True if the translation is available, False otherwise
-            return self.__books_cache[abbreviation] is not None
-        return False
+        negative = self.__negative_books_cache.get(normalized)
+        if negative is not _MISSING:
+            return False
+        cached = self.__books_cache.get(normalized)
+        if cached is not _MISSING:
+            return True
+
+        path = self.__generate_path(normalized, "books.json")
+        books = self.__fetch_data(path)
+        if books is None:
+            self.__negative_books_cache.set(normalized, True)
+            return False
+        self.__books_cache.set(normalized, books)
+        return True
 
     def valid_limit(self, limit: str) -> bool:
-        """
-        Check if the given limit string is valid.
-
-        :param limit: The limit string to check.
-        :return: True if the limit is valid, False otherwise.
-        """
-        parts = limit.split('-')
+        parts = limit.split("-")
         if len(parts) != 4:
             return False
         words, match, case, target = parts
-        return (words in self.WORD_OPTIONS and
-                match in self.MATCH_OPTIONS and
-                case in self.CASE_OPTIONS and
-                target in self.TARGET_OPTIONS)
+        return (
+            words in self.WORD_OPTIONS
+            and match in self.MATCH_OPTIONS
+            and case in self.CASE_OPTIONS
+            and target in self.TARGET_OPTIONS
+        )
 
-    def __start_cache_reset_thread(self) -> None:
-        """
-        Start a background thread to reset the cache monthly.
+    def close(self) -> None:
+        if self.__owns_session:
+            self.__session.close()
 
-        This method creates and starts a daemon thread that runs the cache reset function
-        every month.
-        """
-        reset_thread = threading.Thread(target=self.__reset_cache_monthly)
-        reset_thread.daemon = True  # Daemonize thread
-        reset_thread.start()
+    def __enter__(self) -> "GetBible":
+        return self
 
-    def __reset_cache_monthly(self) -> None:
-        """
-        Periodically clears the cache on the first day of each month.
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.close()
 
-        This method runs in a background thread and calculates the time until the start
-        of the next month. It sleeps until that time and then clears the cache.
-        """
-        while True:
-            time_to_sleep = self.__calculate_time_until_next_month()
-            time.sleep(time_to_sleep)
-            self.__chapters_cache.clear()
-            print(f"Cache cleared on {datetime.now()}")
-
-    def __calculate_time_until_next_month(self) -> float:
-        """
-        Calculate the seconds until the start of the next month.
-
-        Determines how many seconds are left until the first day of the next month
-        from the current time. This duration is used by the cache reset thread to
-        sleep until the cache needs to be cleared.
-
-        :return: Number of seconds until the start of the next month.
-        """
-        now = datetime.now()
-        # Calculate the first day of the next month
-        first_of_next_month = (now.replace(day=1) + timedelta(days=32)).replace(day=1)
-        return (first_of_next_month - now).total_seconds()
-
-    def __set_verse(self, abbreviation: str, book_ref: BookReference, result: Dict) -> None:
-        """
-        Set verse information into the result JSON.
-        :param abbreviation: Bible translation abbreviation.
-        :param book_ref: The book reference class.
-        :param result: The dictionary to store verse information.
-        """
+    def __set_verse(
+        self,
+        abbreviation: str,
+        book_ref: BookReference,
+        result: Dict[str, Union[Dict, str]],
+    ) -> None:
         cache_key = f"{abbreviation}_{book_ref.book}_{book_ref.chapter}"
-        if cache_key not in self.__chapters_cache:
-            chapter_data = self.__retrieve_chapter_data(abbreviation, book_ref.book, book_ref.chapter)
-            # Convert verses list to dictionary for faster lookup
-            verse_dict = {str(v["verse"]): v for v in chapter_data.get("verses", [])}
-            chapter_data["verses"] = verse_dict
-            self.__chapters_cache[cache_key] = chapter_data
-        else:
-            chapter_data = self.__chapters_cache[cache_key]
+        chapter_data = self.__chapters_cache.get(cache_key)
+        if chapter_data is _MISSING:
+            fetched = self.__retrieve_chapter_data(
+                abbreviation, book_ref.book, book_ref.chapter
+            )
+            chapter_data = self.__normalize_chapter_data(fetched)
+            self.__chapters_cache.set(cache_key, chapter_data)
 
+        verse_map = chapter_data["verses"]
         for verse in book_ref.verses:
-            verse_info = chapter_data["verses"].get(str(verse))
+            verse_info = verse_map.get(str(verse))
             if not verse_info:
-                raise ValueError(f"Verse {verse} not found in book {book_ref.book}, chapter {book_ref.chapter}.")
+                raise ScriptureNotFoundError(
+                    f"Verse {verse} not found in book {book_ref.book}, chapter {book_ref.chapter}."
+                )
 
-            if cache_key in result:
-                existing_verses = {str(v["verse"]) for v in result[cache_key].get("verses", [])}
+            existing = result.get(cache_key)
+            if isinstance(existing, dict):
+                existing_verses = {str(item.get("verse")) for item in existing.get("verses", [])}
                 if str(verse) not in existing_verses:
-                    result[cache_key]["verses"].append(verse_info)
-                existing_ref = result[cache_key].get("ref", [])
-                if str(book_ref.reference) not in existing_ref:
-                    result[cache_key]["ref"].append(book_ref.reference)
+                    existing["verses"].append(verse_info)
+                if book_ref.reference not in existing.get("ref", []):
+                    existing["ref"].append(book_ref.reference)
             else:
-                # Include all other relevant elements of your JSON structure
-                result[cache_key] = {key: chapter_data[key] for key in chapter_data if key != "verses"}
-                result[cache_key]["ref"] = [book_ref.reference]
-                result[cache_key]["verses"] = [verse_info]
+                selected = {key: value for key, value in chapter_data.items() if key != "verses"}
+                selected["ref"] = [book_ref.reference]
+                selected["verses"] = [verse_info]
+                result[cache_key] = selected
+
+    def __normalize_chapter_data(self, chapter_data: Any) -> Dict[str, Any]:
+        if not isinstance(chapter_data, dict):
+            raise DataValidationError("Chapter data must be a JSON object.")
+        verses = chapter_data.get("verses")
+        if not isinstance(verses, list):
+            raise DataValidationError("Chapter data is missing its verse list.")
+
+        verse_map = {}
+        for verse in verses:
+            if not isinstance(verse, dict) or "verse" not in verse:
+                raise DataValidationError("Chapter data contains an invalid verse entry.")
+            verse_number = verse["verse"]
+            if not isinstance(verse_number, int) or verse_number < 1:
+                raise DataValidationError("Chapter data contains an invalid verse number.")
+            verse_map[str(verse_number)] = verse
+
+        normalized = dict(chapter_data)
+        normalized["verses"] = verse_map
+        return normalized
 
     def __check_translation(self, abbreviation: str) -> None:
-        """
-        Check if the given translation is available and raises an exception if not found.
-
-        :param abbreviation: The abbreviation of the Bible translation to check.
-        :raises FileNotFoundError: If the translation is not found.
-        """
-        # Use valid_translation to check if the translation is available
         if not self.valid_translation(abbreviation):
-            raise FileNotFoundError(f"Translation ({abbreviation}) not found.")
+            raise TranslationNotFoundError(f"Translation ({abbreviation}) not found.")
 
     def __generate_path(self, abbreviation: str, file_name: str) -> str:
-        """
-        Generate the path or URL for a given file.
-
-        :param abbreviation: Bible translation abbreviation.
-        :param file_name: Name of the file to fetch.
-        :return: Full path or URL to the file.
-        """
         if self.__repo_path_url:
             return f"{self.__repo_path}/{self.__repo_version}/{abbreviation}/{file_name}"
-        else:
-            return os.path.join(self.__repo_path, self.__repo_version, abbreviation, file_name)
+        return os.path.join(self.__repo_path, self.__repo_version, abbreviation, file_name)
 
-    def __fetch_data(self, path: str) -> Optional[Dict]:
-        """
-        Fetch data from either a URL or a local file path.
-
-        :param path: The path or URL to fetch data from.
-        :return: The fetched data, or None if an error occurs.
-        """
+    def __fetch_data(self, path: str) -> Any:
         if self.__repo_path_url:
-            response = requests.get(path)
-            if response.status_code == 200:
-                return response.json()
-            else:
+            try:
+                response = self.__session.get(path, timeout=self.__timeout)
+            except requests.Timeout as error:
+                raise UpstreamUnavailableError("The Scripture repository timed out.") from error
+            except requests.RequestException as error:
+                raise UpstreamUnavailableError("The Scripture repository is unavailable.") from error
+
+            if response.status_code == 404:
                 return None
-        else:
-            if os.path.isfile(path):
-                with open(path, 'r') as file:
-                    return json.load(file)
-            else:
-                return None
+            if response.status_code < 200 or response.status_code >= 300:
+                raise UpstreamUnavailableError(
+                    f"The Scripture repository returned HTTP {response.status_code}."
+                )
+            try:
+                payload = response.json()
+            except (ValueError, requests.RequestException) as error:
+                raise DataValidationError("The Scripture repository returned invalid JSON.") from error
+            if not isinstance(payload, (dict, list)):
+                raise DataValidationError("The Scripture repository returned an invalid JSON value.")
+            return payload
+
+        file_path = Path(path)
+        if not file_path.is_file():
+            return None
+        try:
+            with file_path.open("r", encoding="utf-8") as file_handle:
+                payload = json.load(file_handle)
+        except (OSError, json.JSONDecodeError) as error:
+            raise DataValidationError(f"Unable to read Scripture data from {file_path}.") from error
+        if not isinstance(payload, (dict, list)):
+            raise DataValidationError(f"Scripture data in {file_path} has an invalid shape.")
+        return payload
 
     def __retrieve_chapter_data(self, abbreviation: str, book: int, chapter: int) -> Dict:
-        """
-        Retrieve chapter data for a given book and chapter.
-
-        :param abbreviation: Bible translation abbreviation.
-        :param book: The book of the Bible.
-        :param chapter: The chapter.
-        :return: Chapter data.
-        :raises FileNotFoundError: If the chapter data is not found.
-        """
-        chapter_file = f"{str(book)}/{chapter}.json" if self.__repo_path_url else os.path.join(str(book),
-                                                                                               f"{chapter}.json")
+        chapter_file = (
+            f"{book}/{chapter}.json"
+            if self.__repo_path_url
+            else os.path.join(str(book), f"{chapter}.json")
+        )
         chapter_data = self.__fetch_data(self.__generate_path(abbreviation, chapter_file))
         if chapter_data is None:
-            raise FileNotFoundError(f"Chapter:{chapter} in book:{book} for {abbreviation} not found.")
+            raise ScriptureNotFoundError(
+                f"Chapter:{chapter} in book:{book} for {abbreviation} not found."
+            )
+        if not isinstance(chapter_data, dict):
+            raise DataValidationError("Chapter data must be a JSON object.")
         return chapter_data

--- a/src/getbible/getbible_book_number.py
+++ b/src/getbible/getbible_book_number.py
@@ -1,85 +1,65 @@
 from .getbible_reference_trie import GetBibleReferenceTrie
 import os
-from typing import Any, List, Optional
+from typing import List, Optional
 
 
 class GetBibleBookNumber:
     def __init__(self) -> None:
-        """
-        Initialize the GetBibleBookNumber class.
-
-        Sets up the class by loading all translation tries from the data directory.
-        """
+        """Load the bundled translation tries used to resolve localized book names."""
         self.__tries = {}
-        self.__data_path = os.path.join(os.path.dirname(__file__), 'data')
+        self.__data_path = os.path.join(os.path.dirname(__file__), "data")
         self.__load_all_translations()
 
-    def __load_translation(self, filename: str) -> None:
-        """
-        Load a translation trie from a specified file.
+    @property
+    def translations(self) -> frozenset:
+        """Translation identifiers available in the bundled reference data."""
+        return frozenset(self.__tries)
 
-        :param filename: The name of the file to load.
-        :raises IOError: If there is an error loading the file.
-        """
+    def __load_translation(self, filename: str) -> None:
         trie = GetBibleReferenceTrie()
-        translation_code = filename.split('.')[0]
+        translation_code = filename.rsplit(".", 1)[0]
         try:
             trie.load(os.path.join(self.__data_path, filename))
-        except IOError as e:
-            raise IOError(f"Error loading translation {translation_code}: {e}")
+        except IOError as error:
+            raise IOError(f"Error loading translation {translation_code}: {error}") from error
         self.__tries[translation_code] = trie
 
     def __load_all_translations(self) -> None:
-        """
-        Load all translation tries from the data directory.
-        """
         for filename in os.listdir(self.__data_path):
-            if filename.endswith('.json'):
+            if filename.endswith(".json"):
                 self.__load_translation(filename)
 
-    def __valid_book_number(self, number: str) -> Optional[int]:
-        """
-        Check if the number is a valid book number.
-        """
+    @staticmethod
+    def __valid_book_number(number: str) -> Optional[int]:
         try:
-            num = int(number)
-            if 1 <= num <= 83:
-                return num
-            else:
-                return None
+            parsed = int(number)
         except ValueError:
-            # Handle the case where the number cannot be converted to an integer
             return None
+        return parsed if 1 <= parsed <= 83 else None
 
-    def number(self, reference: str, translation_code: Optional[str] = None,
-               fallback_translations: Optional[List[str]] = None) -> Optional[int]:
-        """
-        Get the book number based on a reference and translation code.
-
-        :param reference: The reference to search for.
-        :param translation_code: The code for the translation to use.
-        :param fallback_translations: A list of fallback translations to use if necessary.
-        :return: The book number as an integer if found, None otherwise.
-        """
+    def number(
+        self,
+        reference: str,
+        translation_code: Optional[str] = None,
+        fallback_translations: Optional[List[str]] = None,
+    ) -> Optional[int]:
         if reference.isdigit():
             return self.__valid_book_number(reference)
 
         if not translation_code or translation_code not in self.__tries:
-            translation_code = 'kjv'
+            translation_code = "kjv"
 
         translation = self.__tries.get(translation_code)
         result = translation.search(reference) if translation else None
         if result and result.isdigit():
             return int(result)
 
-        # If 'kjv' is not the original choice, try it next
-        if translation_code != 'kjv':
-            translation = self.__tries.get('kjv')
+        if translation_code != "kjv":
+            translation = self.__tries.get("kjv")
             result = translation.search(reference) if translation else None
             if result and result.isdigit():
                 return int(result)
 
-        # Fallback to other translations
         if fallback_translations is None:
             fallback_translations = [code for code in self.__tries if code != translation_code]
 
@@ -88,18 +68,9 @@ class GetBibleBookNumber:
             result = translation.search(reference) if translation else None
             if result and result.isdigit():
                 return int(result)
-
         return None
 
     def dump(self, translation_code: str, filename: str) -> None:
-        """
-        Dump the trie data for a specific translation to a file.
-
-        :param translation_code: The code for the translation.
-        :param filename: The name of the file to dump to.
-        :raises ValueError: If no data is available for the specified translation.
-        """
-        if translation_code in self.__tries:
-            self.__tries[translation_code].dump(filename)
-        else:
+        if translation_code not in self.__tries:
             raise ValueError(f"No data available for translation: {translation_code}")
+        self.__tries[translation_code].dump(filename)

--- a/src/getbible/getbible_reference.py
+++ b/src/getbible/getbible_reference.py
@@ -1,165 +1,210 @@
-import re
-from getbible import GetBibleBookNumber
+"""Strict, bounded parsing of Bible references."""
+
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional, Tuple
+import re
+import threading
+import unicodedata
+from typing import List, Optional, Tuple
+
+from getbible.errors import InvalidReferenceError
+from getbible.getbible_book_number import GetBibleBookNumber
 
 
-@dataclass
+@dataclass(frozen=True)
 class BookReference:
+    """Canonical location selected by one user reference."""
+
     book: int
     chapter: int
-    verses: list
+    verses: List[int]
     reference: str
 
 
 class GetBibleReference:
-    def __init__(self):
-        self.__get_book = GetBibleBookNumber()
-        self.__pattern = re.compile(r'[\w\s,:-]{1,50}', re.UNICODE)
-        self.__cache = {}
-        self.__cache_limit = 5000
+    """Parse references without accepting partial or computationally unbounded input."""
+
+    DEFAULT_MAX_REFERENCE_LENGTH = 128
+    DEFAULT_MAX_VERSES = 200
+    DEFAULT_MAX_CHAPTER = 999
+    DEFAULT_MAX_VERSE = 999
+    DEFAULT_CACHE_LIMIT = 5000
+
+    _VERSE_LIST = re.compile(
+        r"\d{1,4}(?:\s*-\s*\d{1,4})?"
+        r"(?:\s*,\s*\d{1,4}(?:\s*-\s*\d{1,4})?)*"
+    )
+    _TRAILING_CHAPTER = re.compile(r"(?P<chapter>\d{1,4})\s*$")
+    _SPACE = re.compile(r"\s+")
+    _ALLOWED_BOOK_PUNCTUATION = frozenset({" ", ".", "-", "'", "’", "ʻ", "ʼ", "־"})
+
+    def __init__(
+        self,
+        max_reference_length: int = DEFAULT_MAX_REFERENCE_LENGTH,
+        max_verses: int = DEFAULT_MAX_VERSES,
+        max_chapter: int = DEFAULT_MAX_CHAPTER,
+        max_verse: int = DEFAULT_MAX_VERSE,
+        cache_limit: int = DEFAULT_CACHE_LIMIT,
+        book_number_resolver: Optional[GetBibleBookNumber] = None,
+    ) -> None:
+        if min(max_reference_length, max_verses, max_chapter, max_verse, cache_limit) < 1:
+            raise ValueError("Parser limits must all be positive integers.")
+
+        self.__get_book = book_number_resolver or GetBibleBookNumber()
+        self.__max_reference_length = max_reference_length
+        self.__max_verses = max_verses
+        self.__max_chapter = max_chapter
+        self.__max_verse = max_verse
+        self.__cache_limit = cache_limit
+        self.__cache = OrderedDict()  # type: OrderedDict[str, BookReference]
+        self.__cache_lock = threading.RLock()
+
+    @property
+    def available_translations(self) -> frozenset:
+        """Return translation identifiers known by the bundled reference data."""
+
+        translations = getattr(self.__get_book, "translations", frozenset())
+        return frozenset(translations)
 
     def ref(self, reference: str, translation_code: Optional[str] = None) -> BookReference:
-        """
-        Fetch the BookReference from cache or create it if not present.
+        """Return a bounded canonical reference or raise ``InvalidReferenceError``."""
 
-        :param reference: Scripture reference string.
-        :param translation_code: Optional translation code.
-        :return: BookReference object.
-        :raises ValueError: If reference is invalid.
-        """
-        sanitized_ref = self.__sanitize(reference)
-        if not sanitized_ref:
-            raise ValueError(f"Invalid reference '{reference}'.")
-        if sanitized_ref not in self.__cache:
-            book_ref = self.__book_reference(reference, translation_code)
-            if book_ref is None:
-                raise ValueError(f"Invalid reference '{reference}'.")
-            self.__manage_local_cache(sanitized_ref, book_ref)
-        return self.__cache[sanitized_ref]
+        normalized_reference = self.__normalize_input(reference)
+        translation_key = (translation_code or "").strip().casefold()
+        cache_key = f"{translation_key}:{normalized_reference.casefold()}"
+
+        with self.__cache_lock:
+            cached = self.__cache.get(cache_key)
+            if cached is not None:
+                self.__cache.move_to_end(cache_key)
+                return cached
+
+        book_name, chapter, verses = self.__parse(normalized_reference)
+        book_number = self.__get_book.number(book_name, translation_code)
+        if not book_number:
+            raise InvalidReferenceError(f"Invalid reference '{reference}'.")
+
+        parsed = BookReference(
+            book=int(book_number),
+            chapter=chapter,
+            verses=verses,
+            reference=normalized_reference,
+        )
+        with self.__cache_lock:
+            self.__cache[cache_key] = parsed
+            self.__cache.move_to_end(cache_key)
+            while len(self.__cache) > self.__cache_limit:
+                self.__cache.popitem(last=False)
+        return parsed
 
     def valid(self, reference: str, translation_code: Optional[str] = None) -> bool:
-        """
-        Validate a scripture reference and check its presence in the cache.
+        """Return ``True`` only when the complete input parses successfully."""
 
-        :param reference: Scripture reference string.
-        :param translation_code: Optional translation code.
-        :return: True if valid and present, False otherwise.
-        """
-        sanitized_ref = self.__sanitize(reference)
-        if sanitized_ref is None:
-            return False
-        if sanitized_ref not in self.__cache:
-            book_ref = self.__book_reference(reference, translation_code)
-            self.__manage_local_cache(sanitized_ref, book_ref)
-        return self.__cache[sanitized_ref] is not None
-
-    def __sanitize(self, reference: str) -> Optional[str]:
-        """
-        Sanitize a scripture reference by validating and escaping it.
-
-        :param reference: The scripture reference to sanitize.
-        :return: Sanitized reference or None if invalid.
-        """
-        if self.__pattern.match(reference):
-            return re.escape(reference)
-        return None
-
-    def __book_reference(self, reference: str, translation_code: Optional[str] = None) -> Optional[BookReference]:
-        """
-        Create a BookReference object from a scripture reference.
-
-        :param reference: Scripture reference string.
-        :param translation_code: Optional translation code.
-        :return: BookReference object or None if invalid.
-        """
         try:
-            book_chapter, verses_portion = self.__split_reference(reference)
-            book_name = self.__extract_book_name(book_chapter)
-            book_number = self.__get_book_number(book_name, translation_code)
-            if not book_number:
-                return None
-            verses_arr = self.__get_verses_numbers(verses_portion)
-            chapter_number = self.__extract_chapter(book_chapter)
-            return BookReference(book=int(book_number), chapter=chapter_number, verses=verses_arr, reference=reference)
-        except Exception:
-            return None
+            self.ref(reference, translation_code)
+        except (InvalidReferenceError, TypeError, ValueError):
+            return False
+        return True
 
-    def __split_reference(self, reference: str) -> Tuple[str, str]:
-        """
-        Split a scripture reference into book chapter and verses portion.
+    def __normalize_input(self, reference: str) -> str:
+        if not isinstance(reference, str):
+            raise InvalidReferenceError("Reference must be text.")
+        normalized = unicodedata.normalize("NFC", reference).strip()
+        if not normalized or len(normalized) > self.__max_reference_length:
+            raise InvalidReferenceError(f"Invalid reference '{reference}'.")
+        if normalized.count(":") > 1:
+            raise InvalidReferenceError(f"Invalid reference '{reference}'.")
+        if any(unicodedata.category(character).startswith("C") for character in normalized):
+            raise InvalidReferenceError(f"Invalid reference '{reference}'.")
+        return normalized
 
-        :param reference: Scripture reference string.
-        :return: Tuple of book chapter and verses portion.
-        """
-        return reference.split(':', 1) if ':' in reference else (reference, '1')
+    def __parse(self, reference: str) -> Tuple[str, int, List[int]]:
+        if ":" in reference:
+            book_chapter, verses_portion = reference.rsplit(":", 1)
+            if not self._VERSE_LIST.fullmatch(verses_portion.strip()):
+                raise InvalidReferenceError(f"Invalid reference '{reference}'.")
+            verses = self.__parse_verses(verses_portion)
+        else:
+            book_chapter = reference
+            verses = [1]
 
-    def __extract_chapter(self, book_chapter: str) -> int:
-        """
-        Extract the chapter number from the book chapter part.
+        book_name, chapter = self.__parse_book_and_chapter(book_chapter, has_verse=":" in reference)
+        self.__validate_book_name(book_name, reference)
+        return book_name, chapter, verses
 
-        :param book_chapter: Book chapter part of the reference.
-        :return: Extracted chapter number.
-        """
-        chapter_match = re.search(r'\d+$', book_chapter)
-        return int(chapter_match.group()) if chapter_match else 1
+    def __parse_book_and_chapter(self, value: str, has_verse: bool) -> Tuple[str, int]:
+        value = value.strip()
+        if not value:
+            raise InvalidReferenceError("Reference is missing a book name.")
 
-    def __extract_book_name(self, book_chapter: str) -> str:
-        """
-        Extract the book name from the book chapter part.
+        # A bare number is a numeric book identifier with the default chapter.
+        if value.isdigit() and not has_verse:
+            return value, 1
 
-        :param book_chapter: Book chapter part of the reference.
-        :return: Extracted book name.
-        """
-        if book_chapter.isdigit():
-            # If the entire string is numeric, return it as is
-            return book_chapter.strip()
+        match = self._TRAILING_CHAPTER.search(value)
+        if match:
+            prefix = value[: match.start()].strip()
+            if prefix:
+                chapter = int(match.group("chapter"))
+                if chapter < 1 or chapter > self.__max_chapter:
+                    raise InvalidReferenceError(f"Chapter must be between 1 and {self.__max_chapter}.")
+                return self._SPACE.sub(" ", prefix), chapter
 
-        chapter_match = re.search(r'\d+$', book_chapter)
-        return book_chapter[:chapter_match.start()].strip() if chapter_match else book_chapter.strip()
+        if has_verse:
+            # ``Genesis:1`` is accepted as book Genesis, chapter 1. A numeric form
+            # such as ``1:1`` means numeric book 1, chapter 1.
+            if value.isdigit():
+                return value, 1
+            return self._SPACE.sub(" ", value), 1
 
-    def __get_verses_numbers(self, verses: str) -> list:
-        """
-        Convert a verses portion of a reference into a list of verse numbers.
+        return self._SPACE.sub(" ", value), 1
 
-        :param verses: Verses portion of the reference.
-        :return: List of verse numbers.
-        """
+    def __validate_book_name(self, book_name: str, original_reference: str) -> None:
+        if not book_name:
+            raise InvalidReferenceError(f"Invalid reference '{original_reference}'.")
+        for character in book_name:
+            category = unicodedata.category(character)
+            if category[0] in {"L", "M", "N"} or character in self._ALLOWED_BOOK_PUNCTUATION:
+                continue
+            raise InvalidReferenceError(f"Invalid reference '{original_reference}'.")
+
+    def __parse_verses(self, value: str) -> List[int]:
+        verses = []  # type: List[int]
+        seen = set()
+        for part in value.split(","):
+            part = part.strip()
+            if "-" in part:
+                start_text, end_text = (component.strip() for component in part.split("-", 1))
+                start = self.__validate_verse_number(start_text)
+                end = self.__validate_verse_number(end_text)
+                if start > end:
+                    raise InvalidReferenceError("Verse ranges must be in ascending order.")
+                range_size = end - start + 1
+                if range_size > self.__max_verses or len(verses) + range_size > self.__max_verses:
+                    raise InvalidReferenceError(
+                        f"A reference may select at most {self.__max_verses} verses."
+                    )
+                candidates = range(start, end + 1)
+            else:
+                candidates = (self.__validate_verse_number(part),)
+
+            for verse in candidates:
+                if verse not in seen:
+                    seen.add(verse)
+                    verses.append(verse)
+                    if len(verses) > self.__max_verses:
+                        raise InvalidReferenceError(
+                            f"A reference may select at most {self.__max_verses} verses."
+                        )
+
         if not verses:
-            return [1]
-        verse_parts = verses.split(',')
-        verse_list = []
-        for part in verse_parts:
-            if '-' in part:
-                range_parts = part.split('-')
-                if all(rp.isdigit() for rp in range_parts):
-                    start, end = sorted(map(int, range_parts))
-                    verse_list.extend(range(start, end + 1))
-                elif len(range_parts) == 2 and range_parts[0].isdigit() and not range_parts[1]:
-                    verse_list.append(int(range_parts[0]))
-                elif len(range_parts) == 2 and range_parts[1].isdigit() and not range_parts[0]:
-                    verse_list.append(int(range_parts[1]))
-            elif part.isdigit():
-                verse_list.append(int(part))
-        return verse_list if verse_list else [1]
+            raise InvalidReferenceError("A reference must select at least one verse.")
+        return verses
 
-    def __get_book_number(self, book_name: str, abbreviation: Optional[str]) -> Optional[int]:
-        """
-        Retrieve the book number given a book name and translation abbreviation.
-
-        :param book_name: Name of the book.
-        :param abbreviation: Translation abbreviation.
-        :return: Book number or None if not found.
-        """
-        return self.__get_book.number(book_name, abbreviation)
-
-    def __manage_local_cache(self, key: str, value: Optional[BookReference]):
-        """
-        Manage the insertion and eviction policy for the cache.
-
-        :param key: The key to insert into the cache.
-        :param value: The value to associate with the key.
-        """
-        if len(self.__cache) >= self.__cache_limit:
-            self.__cache.pop(next(iter(self.__cache)))  # Evict the oldest cache item
-        self.__cache[key] = value
+    def __validate_verse_number(self, value: str) -> int:
+        if not value.isdigit():
+            raise InvalidReferenceError("Verse numbers must be positive integers.")
+        verse = int(value)
+        if verse < 1 or verse > self.__max_verse:
+            raise InvalidReferenceError(f"Verse must be between 1 and {self.__max_verse}.")
+        return verse

--- a/tests/test_getbible.py
+++ b/tests/test_getbible.py
@@ -1,192 +1,65 @@
-import unittest
 import json
-from getbible import GetBible
+from pathlib import Path
+import tempfile
+import unittest
+
+from getbible import GetBible, InvalidReferenceError, ScriptureNotFoundError
 
 
-class TestGetBible(unittest.TestCase):
-
+class TestGetBibleOffline(unittest.TestCase):
     def setUp(self):
-        self.getbible = GetBible()
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name) / "v2" / "kjv"
+        (self.root / "43").mkdir(parents=True)
+        (self.root / "books.json").write_text("{}", encoding="utf-8")
+        chapter = {
+            "translation": "King James Version",
+            "abbreviation": "kjv",
+            "lang": "en",
+            "language": "English",
+            "direction": "LTR",
+            "encoding": "UTF-8",
+            "book_nr": 43,
+            "book_name": "John",
+            "chapter": 3,
+            "name": "John 3",
+            "verses": [
+                {
+                    "chapter": 3,
+                    "verse": 16,
+                    "name": "John 3:16",
+                    "text": "For God so loved the world.",
+                }
+            ],
+        }
+        (self.root / "43" / "3.json").write_text(json.dumps(chapter), encoding="utf-8")
+        self.getbible = GetBible(
+            repo_path=self.temporary_directory.name,
+            max_references=2,
+            max_total_verses=10,
+        )
+
+    def tearDown(self):
+        self.getbible.close()
+        self.temporary_directory.cleanup()
 
     def test_valid_reference(self):
-        actual_result = json.loads(self.getbible.scripture('Gen 1:2-7', 'kjv'))
-        expected_result = {
-            "kjv_1_1": {"translation": "King James Version", "abbreviation": "kjv", "lang": "en", "language": "English",
-                        "direction": "LTR", "encoding": "UTF-8", "book_nr": 1, "book_name": "Genesis", "chapter": 1,
-                        "name": "Genesis 1", "ref": ["Gen 1:2-7"], "verses": [{"chapter": 1, "verse": 2, "name": "Genesis 1:2",
-                                                         "text": "And the earth was without form and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters."},
-                                                        {"chapter": 1, "verse": 3, "name": "Genesis 1:3",
-                                                         "text": "And God said, Let there be light: and there was light."},
-                                                        {"chapter": 1, "verse": 4, "name": "Genesis 1:4",
-                                                         "text": "And God saw the light, that it was good: and God divided the light from the darkness."},
-                                                        {"chapter": 1, "verse": 5, "name": "Genesis 1:5",
-                                                         "text": "And God called the light Day, and the darkness he called Night. And the evening and the morning were the first day."},
-                                                        {"chapter": 1, "verse": 6, "name": "Genesis 1:6",
-                                                         "text": "And God said, Let there be a firmament in the midst of the waters, and let it divide the waters from the waters."},
-                                                        {"chapter": 1, "verse": 7, "name": "Genesis 1:7",
-                                                         "text": "And God made the firmament, and divided the waters which were under the firmament from the waters which were above the firmament: and it was so."}]}}
-        self.assertEqual(actual_result, expected_result, "Failed to find 'Gen 1:2-7' scripture.")
+        result = self.getbible.select("John 3:16", "kjv")
+        self.assertEqual(result["kjv_43_3"]["verses"][0]["verse"], 16)
+        self.assertEqual(result["kjv_43_3"]["ref"], ["John 3:16"])
 
-    def test_valid_reference_cns(self):
-        actual_result = json.loads(self.getbible.scripture('创世记1:2-7', 'cns'))
-        expected_result = {
-            "cns_1_1": {"translation": "NCV Simplified", "abbreviation": "cns", "lang": "zh-Hans",
-                        "language": "Chinese",
-                        "direction": "LTR", "encoding": "UTF-8", "book_nr": 1, "book_name": "\ufeff\u521b\u4e16\u8bb0",
-                        "chapter": 1, "name": "\ufeff\u521b\u4e16\u8bb0 1", "ref": ["创世记1:2-7"], "verses": [
-                    {"chapter": 1, "verse": 2, "name": "\ufeff\u521b\u4e16\u8bb0 1:2",
-                     "text": "\u5730\u662f\u7a7a\u865a\u6df7\u6c8c\uff1b\u6df1\u6e0a\u4e0a\u4e00\u7247\u9ed1\u6697\uff1b\u3000\u795e\u7684\u7075\u8fd0\u884c\u5728\u6c34\u9762\u4e0a\u3002 "},
-                    {"chapter": 1, "verse": 3, "name": "\ufeff\u521b\u4e16\u8bb0 1:3",
-                     "text": "\u795e\u8bf4\uff1a\u201c\u8981\u6709\u5149\uff01\u201d\u5c31\u6709\u4e86\u5149\u3002 "},
-                    {"chapter": 1, "verse": 4, "name": "\ufeff\u521b\u4e16\u8bb0 1:4",
-                     "text": "\u795e\u770b\u5149\u662f\u597d\u7684\uff0c\u4ed6\u5c31\u628a\u5149\u6697\u5206\u5f00\u4e86\u3002 "},
-                    {"chapter": 1, "verse": 5, "name": "\ufeff\u521b\u4e16\u8bb0 1:5",
-                     "text": "\u795e\u79f0\u5149\u4e3a\u663c\uff0c\u79f0\u6697\u4e3a\u591c\u3002\u6709\u665a\u4e0a\uff0c\u6709\u65e9\u6668\uff1b\u8fd9\u662f\u7b2c\u4e00\u65e5\u3002 "},
-                    {"chapter": 1, "verse": 6, "name": "\ufeff\u521b\u4e16\u8bb0 1:6",
-                     "text": "\u795e\u8bf4\uff1a\u201c\u4f17\u6c34\u4e4b\u95f4\u8981\u6709\u7a79\u82cd\uff0c\u628a\u6c34\u548c\u6c34\u5206\u5f00\uff01\u201d\u4e8b\u5c31\u8fd9\u6837\u6210\u4e86\u3002 "},
-                    {"chapter": 1, "verse": 7, "name": "\ufeff\u521b\u4e16\u8bb0 1:7",
-                     "text": "\u795e\u9020\u4e86\u7a79\u82cd\uff0c\u628a\u7a79\u82cd\u4ee5\u4e0b\u7684\u6c34\u548c\u7a79\u82cd\u4ee5\u4e0a\u7684\u6c34\u5206\u5f00\u4e86\u3002 "}]}}
-        self.assertEqual(actual_result, expected_result, "Failed to find '创世记1:2-7' scripture.")
+    def test_scripture_json_is_unicode_safe(self):
+        result = json.loads(self.getbible.scripture("John 3:16", "kjv"))
+        self.assertEqual(result["kjv_43_3"]["book_name"], "John")
 
-    def test_valid_multiple_reference_aov(self):
-        actual_result = json.loads(self.getbible.scripture('Ge1:1;Jn1:1;1Jn1:1', 'aov'))
-        expected_result = {
-            "aov_1_1": {"translation": "Ou Vertaling", "abbreviation": "aov", "lang": "af", "language": "Afrikaans",
-                        "direction": "LTR", "encoding": "UTF-8", "book_nr": 1, "book_name": "Genesis", "chapter": 1,
-                        "name": "Genesis 1", "ref": ['Ge1:1'], "verses": [{"chapter": 1, "verse": 1, "name": "Genesis 1:1",
-                                                         "text": "In die begin het God die hemel en die aarde geskape. "}]},
-            "aov_43_1": {"translation": "Ou Vertaling", "abbreviation": "aov", "lang": "af", "language": "Afrikaans",
-                         "direction": "LTR", "encoding": "UTF-8", "book_nr": 43, "book_name": "Johannes", "chapter": 1,
-                         "name": "Johannes 1", "ref": ['Jn1:1'], "verses": [{"chapter": 1, "verse": 1, "name": "Johannes 1:1",
-                                                           "text": "In die begin was die Woord, en die Woord was by God, en die Woord was God. "}]},
-            "aov_62_1": {"translation": "Ou Vertaling", "abbreviation": "aov", "lang": "af", "language": "Afrikaans",
-                         "direction": "LTR", "encoding": "UTF-8", "book_nr": 62, "book_name": "1 Johannes",
-                         "chapter": 1, "name": "1 Johannes 1", "ref": ["1Jn1:1"], "verses": [
-                    {"chapter": 1, "verse": 1, "name": "1 Johannes 1:1",
-                     "text": "Wat van die begin af was, wat ons gehoor het, wat ons met ons o\u00eb gesien het, wat ons aanskou het en ons hande getas het aangaande die Woord van die lewe \u2014 "}]}}
-        self.assertEqual(actual_result, expected_result, "Failed to find 'Ge1:1;Jn1:1;1Jn1:1' scripture.")
+    def test_missing_verse_has_typed_error(self):
+        with self.assertRaises(ScriptureNotFoundError):
+            self.getbible.select("John 3:17", "kjv")
 
-    def test_valid_multiple_reference_select_aleppo(self):
-        actual_result = self.getbible.select('ברא 1:1-3;תה 1:1;תה1:1-2;בְּרֵאשִׁית 1:6-7,10', 'aleppo')
-        expected_result = {
-            'aleppo_19_1': {'abbreviation': 'aleppo',
-                            'book_name': 'תְּהִלִּים',
-                            'book_nr': 19,
-                            'chapter': 1,
-                            'direction': 'RTL',
-                            'encoding': 'UTF-8',
-                            'lang': 'hbo',
-                            'language': 'Hebrew',
-                            'name': 'תְּהִלִּים 1',
-                            'translation': 'Aleppo Codex',
-                            'ref': ['תה 1:1', 'תה1:1-2'],
-                            'verses': [{'chapter': 1,
-                                        'name': 'תְּהִלִּים 1:1',
-                                        'text': '\xa0\xa0אשרי האיש— \xa0\xa0 אשר לא הלך '
-                                                'בעצת רשעיםובדרך חטאים לא עמד \xa0\xa0 '
-                                                'ובמושב לצים לא ישב ',
-                                        'verse': 1},
-                                       {'chapter': 1,
-                                        'name': 'תְּהִלִּים 1:2',
-                                        'text': '\xa0\xa0כי אם בתורת יהוה חפצו \xa0\xa0 '
-                                                'ובתורתו יהגה יומם ולילה ',
-                                        'verse': 2}]},
-            'aleppo_1_1': {'abbreviation': 'aleppo',
-                           'book_name': 'בְּרֵאשִׁית',
-                           'book_nr': 1,
-                           'chapter': 1,
-                           'direction': 'RTL',
-                           'encoding': 'UTF-8',
-                           'lang': 'hbo',
-                           'language': 'Hebrew',
-                           'name': 'בְּרֵאשִׁית 1',
-                           'translation': 'Aleppo Codex',
-                           'ref': ['ברא 1:1-3', 'בְּרֵאשִׁית 1:6-7,10'],
-                           'verses': [{'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:1',
-                                       'text': 'בראשית ברא אלהים את השמים ואת הארץ ',
-                                       'verse': 1},
-                                      {'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:2',
-                                       'text': 'והארץ היתה תהו ובהו וחשך על פני תהום ורוח '
-                                               'אלהים מרחפת על פני המים ',
-                                       'verse': 2},
-                                      {'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:3',
-                                       'text': 'ויאמר אלהים יהי אור ויהי אור ',
-                                       'verse': 3},
-                                      {'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:6',
-                                       'text': 'ויאמר אלהים יהי רקיע בתוך המים ויהי מבדיל '
-                                               'בין מים למים ',
-                                       'verse': 6},
-                                      {'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:7',
-                                       'text': 'ויעש אלהים את הרקיע ויבדל בין המים אשר '
-                                               'מתחת לרקיע ובין המים אשר מעל לרקיע ויהי '
-                                               'כן ',
-                                       'verse': 7},
-                                      {'chapter': 1,
-                                       'name': 'בְּרֵאשִׁית 1:10',
-                                       'text': 'ויקרא אלהים ליבשה ארץ ולמקוה המים קרא '
-                                               'ימים וירא אלהים כי טוב ',
-                                       'verse': 10}]
-                           }
-        }
+    def test_request_limits(self):
+        with self.assertRaises(InvalidReferenceError):
+            self.getbible.select("John 3:16;John 3:16;John 3:16", "kjv")
 
-        self.assertEqual(actual_result, expected_result, "Failed to find 'Ge1:1-3;Ps1:1;ps1:1-2;Ge1:6-7,1' scripture.")
 
-    def test_valid_single_reference_select_aleppo(self):
-        actual_result = json.loads(self.getbible.scripture('בְּרֵאשִׁית 1:26', 'aleppo'))
-        expected_result = {'aleppo_1_1': {'abbreviation': 'aleppo',
-                'book_name': 'בְּרֵאשִׁית',
-                'book_nr': 1,
-                'chapter': 1,
-                'direction': 'RTL',
-                'encoding': 'UTF-8',
-                'lang': 'hbo',
-                'language': 'Hebrew',
-                'name': 'בְּרֵאשִׁית 1',
-                'ref': ['בְּרֵאשִׁית 1:26'],
-                'translation': 'Aleppo Codex',
-                'verses': [{'chapter': 1,
-                            'name': 'בְּרֵאשִׁית 1:26',
-                            'text': 'ויאמר אלהים נעשה אדם בצלמנו כדמותנו וירדו '
-                                    'בדגת הים ובעוף השמים ובבהמה ובכל הארץ '
-                                    'ובכל הרמש הרמש על הארץ ',
-                            'verse': 26}]}}
-
-        self.assertEqual(actual_result, expected_result, "Failed to find 'בְּרֵאשִׁית 1:26' scripture.")
-
-    def test_invalid_reference_select_aleppo(self):
-        expected_exception = "Chapter:111 in book:1 for aleppo not found."
-        with self.assertRaises(FileNotFoundError) as actual:
-            self.getbible.select('Ge111', 'aleppo')
-        self.assertEqual(str(actual.exception), expected_exception)
-
-    def test_invalid_reference_select_kjv(self):
-        expected_exception = "Verse 111 not found in book 1, chapter 1."
-        with self.assertRaises(ValueError) as actual:
-            self.getbible.select('Ge 1:111', 'kjv')
-        self.assertEqual(str(actual.exception), expected_exception)
-
-    def test_invalid_double_dash_reference_select_kjv(self):
-        expected_exception = "Invalid reference 'Ge 1:1-7-11'."
-        with self.assertRaises(ValueError) as actual:
-            self.getbible.select('Ge 1:1-7-11', 'kjv')
-        self.assertEqual(str(actual.exception), expected_exception)
-
-    def test_invalid_verse_reference_select_kjv(self):
-        expected_exception = "Verse 32 not found in book 1, chapter 1."
-        with self.assertRaises(ValueError) as actual:
-            self.getbible.select('1 1:1-80', 'kjv')
-        self.assertEqual(str(actual.exception), expected_exception)
-
-    def test_invalid_book_reference_select_kjv(self):
-        expected_exception = "Invalid reference '112 1:1-80'."
-        with self.assertRaises(ValueError) as actual:
-            self.getbible.select('112 1:1-80', 'kjv')
-        self.assertEqual(str(actual.exception), expected_exception)
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_getbible_reference.py
+++ b/tests/test_getbible_reference.py
@@ -1,88 +1,43 @@
+import time
 import unittest
-from getbible import GetBibleReference
-from getbible import BookReference
+
+from getbible import BookReference, GetBibleReference, InvalidReferenceError
 
 
 class TestGetBibleReference(unittest.TestCase):
     def setUp(self):
-        self.get = GetBibleReference()
+        self.parser = GetBibleReference(max_verses=100)
 
-    def test_valid_reference(self):
-        actual_result = self.get.ref('Gen 1:2-7', 'kjv')
-        expected_result = BookReference(book=1, chapter=1, verses=[2, 3, 4, 5, 6, 7], reference='Gen 1:2-7')
-        self.assertEqual(actual_result, expected_result, "Failed to find 'Gen 1:2-7' book reference.")
-
-    def test_valid_genesis_hebrew(self):
-        actual_result = self.get.ref('בְּרֵאשִׁית 1:23-30', 'codex')
-        expected_result = BookReference(book=1, chapter=1, verses=[23, 24, 25, 26, 27, 28, 29, 30], reference='בְּרֵאשִׁית 1:23-30')
-        self.assertEqual(actual_result, expected_result, "Failed to find 'בְּרֵאשִׁית 1:23-30' in 'codex' translation")
-
-    def test_valid_reference_ch(self):
-        actual_result = self.get.ref('创世记1:2-7', 'cns')
-        expected_result = BookReference(book=1, chapter=1, verses=[2, 3, 4, 5, 6, 7], reference='创世记1:2-7')
-        self.assertEqual(actual_result, expected_result, "Failed to find '创世记1:2-7' book reference")
-
-    def test_valid_reference_missing_verse_ch(self):
-        actual_result = self.get.ref('创记 1:2-', 'cus')
-        expected_result = BookReference(book=1, chapter=1, verses=[2], reference='创记 1:2-')
-        self.assertEqual(actual_result, expected_result, "Failed to find '创记 1:2-' book reference")
-
-    def test_valid_reference_missing_verse__ch(self):
-        actual_result = self.get.ref('创记 1:-5', 'cus')
-        expected_result = BookReference(book=1, chapter=1, verses=[5], reference='创记 1:-5')
-        self.assertEqual(actual_result, expected_result, "Failed to find '创记 1:-5' book reference")
-
-    def test_valid_revelation_arabic(self):
-        actual_result = self.get.ref('رؤ 22:19')
-        expected_result = BookReference(book=66, chapter=22, verses=[19], reference='رؤ 22:19')
-        self.assertEqual(actual_result, expected_result, "Failed to find 'رؤ 22:19' in 'arabicsv' translation")
-
-    def test_valid_reference_ch_no_trans(self):
-        actual_result = self.get.ref('创世记')
-        expected_result = BookReference(book=1, chapter=1, verses=[1], reference='创世记')
-        self.assertEqual(actual_result, expected_result, "Failed to find '创世记 1:1' book reference")
-
-    def test_valid_reference_ch_no__trans(self):
-        expected_result = BookReference(book=1, chapter=1, verses=[1], reference='创记')
-        actual_result = self.get.ref('创记')
-        self.assertEqual(actual_result, expected_result, "Failed to find '创记 1:1' book reference")
-
-    def test_valid_1_john(self):
-        actual_result = self.get.ref('1 John', 'kjv')
-        expected_result = BookReference(book=62, chapter=1, verses=[1], reference='1 John')
-        self.assertEqual(actual_result, expected_result, "Failed to find '1 John 1:1' book reference")
-
-    def test_valid_1_peter_ch(self):
-        actual_result = self.get.ref('彼得前书', 'cns')
-        expected_result = BookReference(book=60, chapter=1, verses=[1], reference='彼得前书')
-        self.assertEqual(actual_result, expected_result, "Failed to find '彼得前书 1:1' book reference")
-
-    def test_valid_first_john(self):
-        actual_result = self.get.ref('First John 3:16,19-21', 'kjv')
-        expected_result = BookReference(book=62, chapter=3, verses=[16, 19, 20, 21], reference='First John 3:16,19-21')
-        self.assertEqual(actual_result, expected_result, "Failed to find 'First John 1:2-7' book reference.")
-
-    def test_valid_mismatch_nospace_call(self):
-        actual_result = self.get.ref('1Jn', 'aov')
-        expected_result = BookReference(book=62, chapter=1, verses=[1], reference='1Jn')
-        self.assertEqual(actual_result, expected_result, "Failed to find '1Jn 1:1' book reference.")
-
-    def test_valid_mismatch_call(self):
-        actual_result = self.get.ref('1  John 5', 'aov')
-        expected_result = BookReference(book=62, chapter=5, verses=[1], reference='1  John 5')
-        self.assertEqual(actual_result, expected_result, "Failed to find '1  John 5:1' book reference.")
+    def test_valid_multilingual_references(self):
+        cases = (
+            ("Gen 1:2-7", "kjv", BookReference(1, 1, [2, 3, 4, 5, 6, 7], "Gen 1:2-7")),
+            ("创世记1:2-7", "cns", BookReference(1, 1, [2, 3, 4, 5, 6, 7], "创世记1:2-7")),
+            ("رؤ 22:19", None, BookReference(66, 22, [19], "رؤ 22:19")),
+            ("1Jn", "aov", BookReference(62, 1, [1], "1Jn")),
+        )
+        for reference, translation, expected in cases:
+            with self.subTest(reference=reference):
+                self.assertEqual(self.parser.ref(reference, translation), expected)
 
     def test_invalid_reference(self):
-        expected_exception = "Invalid reference 'NonExistent'."
-        with self.assertRaises(ValueError) as actual:
-            self.get.ref('NonExistent', 'kjv')
-        self.assertEqual(str(actual.exception), expected_exception)
+        with self.assertRaises(InvalidReferenceError):
+            self.parser.ref("NonExistent", "kjv")
 
-    def test_nonexistent_translation(self):
-        actual_result = self.get.ref('Gen', 'nonexistent')
-        expected_result = BookReference(book=1, chapter=1, verses=[1], reference='Gen')
-        self.assertEqual(actual_result, expected_result, "Failed to find 'Gen 1:1' book reference.")
+    def test_dangling_and_reversed_ranges_are_invalid(self):
+        for reference in ("John 1:2-", "John 1:-5", "John 1:10-2"):
+            with self.subTest(reference=reference), self.assertRaises(InvalidReferenceError):
+                self.parser.ref(reference, "kjv")
+
+    def test_partial_match_is_never_accepted(self):
+        with self.assertRaises(InvalidReferenceError):
+            self.parser.ref("John 1:16!", "kjv")
+
+    def test_huge_range_fails_quickly(self):
+        started = time.monotonic()
+        with self.assertRaises(InvalidReferenceError):
+            self.parser.ref("John 1:1-999999999", "kjv")
+        self.assertLess(time.monotonic() - started, 0.1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,184 @@
+import json
+import time
+import unittest
+
+import requests
+
+from getbible import (
+    DataValidationError,
+    GetBible,
+    GetBibleReference,
+    InvalidReferenceError,
+    UpstreamUnavailableError,
+)
+
+
+class FakeBookNumbers:
+    translations = frozenset({"kjv", "aov"})
+
+    def __init__(self):
+        self.calls = []
+
+    def number(self, reference, translation_code=None, fallback_translations=None):
+        self.calls.append((reference, translation_code))
+        values = {
+            "gen": 1,
+            "genesis": 1,
+            "john": 43,
+            "1 john": 62,
+            "1jn": 62,
+            "创世记": 1,
+            "בְּרֵאשִׁית": 1,
+        }
+        if str(reference).isdigit():
+            number = int(reference)
+            return number if 1 <= number <= 83 else None
+        return values.get(str(reference).casefold())
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.headers = {}
+
+    def get(self, path, timeout):
+        self.calls.append((path, timeout))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def close(self):
+        return None
+
+
+class ReferenceHardeningTests(unittest.TestCase):
+    def setUp(self):
+        self.books = FakeBookNumbers()
+        self.parser = GetBibleReference(
+            max_verses=100,
+            book_number_resolver=self.books,
+        )
+
+    def test_valid_multilingual_and_compact_references(self):
+        self.assertEqual(self.parser.ref("John 3:16", "kjv").verses, [16])
+        self.assertEqual(self.parser.ref("1Jn1:1", "kjv").book, 62)
+        self.assertEqual(self.parser.ref("创世记1:2-4", "kjv").verses, [2, 3, 4])
+        self.assertEqual(self.parser.ref("בְּרֵאשִׁית 1:1", "kjv").book, 1)
+
+    def test_huge_range_is_rejected_before_allocation(self):
+        started = time.monotonic()
+        with self.assertRaises(InvalidReferenceError):
+            self.parser.ref("John 1:1-999999999", "kjv")
+        self.assertLess(time.monotonic() - started, 0.1)
+
+    def test_work_budget_rejects_large_but_syntactic_range(self):
+        with self.assertRaisesRegex(InvalidReferenceError, "at most 100"):
+            self.parser.ref("John 1:1-101", "kjv")
+
+    def test_partial_match_and_dangling_ranges_are_rejected(self):
+        for value in ("John 1:16!", "John 1:2-", "John 1:-5", "John 1:1-3junk"):
+            with self.subTest(value=value), self.assertRaises(InvalidReferenceError):
+                self.parser.ref(value, "kjv")
+
+    def test_reversed_range_is_rejected(self):
+        with self.assertRaisesRegex(InvalidReferenceError, "ascending"):
+            self.parser.ref("John 1:10-2", "kjv")
+
+    def test_invalid_input_never_falls_back_to_verse_one(self):
+        with self.assertRaises(InvalidReferenceError):
+            self.parser.ref("John 1:garbage", "kjv")
+
+    def test_cache_key_includes_translation(self):
+        self.parser.ref("John 1:1", "kjv")
+        self.parser.ref("John 1:1", "aov")
+        self.assertEqual(self.books.calls, [("John", "kjv"), ("John", "aov")])
+
+
+class ClientHardeningTests(unittest.TestCase):
+    @staticmethod
+    def parser(max_verses=100):
+        return GetBibleReference(
+            max_verses=max_verses,
+            book_number_resolver=FakeBookNumbers(),
+        )
+
+    def test_unknown_translation_performs_no_request(self):
+        session = FakeSession([])
+        client = GetBible(session=session, reference_parser=self.parser())
+        self.assertFalse(client.valid_translation("3:16"))
+        self.assertFalse(client.valid_translation("not_known"))
+        self.assertEqual(session.calls, [])
+
+    def test_timeout_is_explicit_and_mapped(self):
+        session = FakeSession([requests.Timeout("late")])
+        client = GetBible(
+            session=session,
+            reference_parser=self.parser(),
+            connect_timeout=1.5,
+            read_timeout=4.5,
+        )
+        with self.assertRaises(UpstreamUnavailableError):
+            client.valid_translation("kjv")
+        self.assertEqual(session.calls[0][1], (1.5, 4.5))
+
+    def test_invalid_json_is_not_treated_as_missing_translation(self):
+        session = FakeSession([FakeResponse(payload=ValueError("bad json"))])
+        client = GetBible(session=session, reference_parser=self.parser())
+        with self.assertRaises(DataValidationError):
+            client.valid_translation("kjv")
+
+    def test_reference_and_total_verse_limits_are_enforced(self):
+        session = FakeSession([FakeResponse(payload={})])
+        client = GetBible(
+            session=session,
+            reference_parser=self.parser(max_verses=10),
+            max_references=2,
+            max_total_verses=10,
+        )
+        with self.assertRaisesRegex(InvalidReferenceError, "at most 2 references"):
+            client.select("John 1:1;John 1:2;John 1:3", "kjv")
+        with self.assertRaisesRegex(InvalidReferenceError, "at most 10 verses"):
+            client.select("John 1:1-6;John 1:7-12", "kjv")
+
+    def test_local_repository_happy_path(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "v2" / "kjv"
+            (root / "43").mkdir(parents=True)
+            (root / "books.json").write_text("{}", encoding="utf-8")
+            chapter = {
+                "translation": "King James Version",
+                "abbreviation": "kjv",
+                "book_name": "John",
+                "chapter": 3,
+                "verses": [
+                    {"chapter": 3, "verse": 16, "text": "For God so loved the world."}
+                ],
+            }
+            (root / "43" / "3.json").write_text(json.dumps(chapter), encoding="utf-8")
+            client = GetBible(
+                repo_path=directory,
+                reference_parser=self.parser(),
+                max_total_verses=10,
+            )
+            result = client.select("John 3:16", "kjv")
+            self.assertEqual(result["kjv_43_3"]["verses"][0]["verse"], 16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replaces permissive partial-match parsing with complete, Unicode-aware reference parsing
- rejects malformed suffixes, dangling/reversed ranges, oversized numbers, excessive ranges, and requests over hard verse/reference budgets
- includes the translation in reference-cache keys
- exposes a local translation registry so arbitrary tokens never trigger translation probes
- replaces unbounded monthly caches and their background thread with bounded, thread-safe TTL/LRU caches
- adds explicit connect/read timeouts, bounded retries, pooled sessions, typed upstream/data errors, response-shape validation, and local-data support
- replaces network-dependent tests with deterministic offline coverage and adds focused security regressions
- adds dependency, CI, security-policy, Dependabot, and release-gate improvements
- prevents automatic PyPI publication on every master push; publication now requires a tested `v*` tag and the protected `pypi` environment

## Why

The previous parser could materialize attacker-controlled ranges such as `1-999999999`, accepted malformed inputs by prefix, silently converted malformed verse portions to verse 1, and cached translation-dependent results under translation-independent keys. The HTTP client also had no timeout and caches were unbounded or cleared from an unsynchronized background thread.

## Developer and user impact

Malformed references now fail explicitly instead of being repaired silently. Dangling ranges such as `2-` and `-5` are intentionally no longer accepted. Public callers receive typed exceptions and can map them to safe UI messages. The default request budget is eight references and 200 verses and is configurable.

## Validation

Locally reconstructed package tests: 21/21 passed, including huge-range, malformed-suffix, reversed-range, translation-cache, timeout, invalid-JSON, offline lookup, and total-work cases. The branch CI runs the full repository test suite on Python 3.9–3.13 plus Ruff, Bandit, dependency audit, and token-pattern scanning.

## Coordination

This draft is the dependency for the paired `getbible/robot` hardening PR. The robot branch will pin this exact commit until version 1.2.0 is released.