### PR TITLE
Harden reference parsing and repository boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
@@ -22,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -39,8 +43,26 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .
 
+      - name: Compile source
+        run: python -m compileall -q src tests
+
       - name: Run deterministic tests
-        run: python -m unittest discover -s tests -v
+        run: |
+          set +e
+          python -m unittest discover -s tests -v > test-output.log 2>&1
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            tail -n 200 test-output.log
+          fi
+          exit "$status"
+
+      - name: Upload test failure log
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: test-failure-python-${{ matrix.python-version }}
+          path: test-output.log
+          if-no-files-found: error
 
   quality:
     name: Quality and package
@@ -49,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
           cache: pip
@@ -66,7 +88,48 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: Lint
-        run: ruff check src tests benchmarks scripts examples
+        run: |
+          set +e
+          ruff check src tests benchmarks scripts examples --output-format=concise \
+            > quality-output.log 2>&1
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            cat quality-output.log
+          fi
+          exit "$status"
+
+      - name: Upload quality failure log
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: quality-failure
+          path: quality-output.log
+          if-no-files-found: error
+
+      - name: Static security scan
+        run: |
+          set +e
+          bandit -q -r src/getbible -x src/getbible/data > security-output.log 2>&1
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            cat security-output.log
+          fi
+          exit "$status"
+
+      - name: Upload security failure log
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: security-failure
+          path: |
+            security-output.log
+            src/getbible/getbible.py
+            src/getbible/search.py
+            src/getbible/translation_cache.py
+          if-no-files-found: error
+
+      - name: Dependency vulnerability scan
+        run: python -m pip_audit
 
       - name: Build distributions
         run: python -m build
@@ -79,10 +142,10 @@ jobs:
           python -m venv "${RUNNER_TEMP}/getbible-wheel"
           "${RUNNER_TEMP}/getbible-wheel/bin/python" -m pip install dist/*.whl
           cd "${RUNNER_TEMP}"
-          "${RUNNER_TEMP}/getbible-wheel/bin/python" -c "from getbible import GetBible, SearchBible; assert SearchBible().limit == 100; GetBible()"
+          "${RUNNER_TEMP}/getbible-wheel/bin/python" -c "from getbible import GetBible, RequestLimits, SearchBible; assert SearchBible().limit == 100; assert RequestLimits().max_references == 8; GetBible().close()"
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: getbible-distributions
           path: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable project changes are documented here.
 - Repository architecture, operations, caching, search, usage, and release documentation.
 - Explicit translation/index warm-up, JSON-safe cache telemetry, and orderly HTTP session shutdown APIs.
 - Configurable bounded LRU retention for references, books, chapters, translation snapshots, and search corpora.
+- Typed reference, work-budget, translation, timeout, and oversized-response exceptions.
+- Request-level reference, verse, search-pagination, and response-body budgets.
+- Bounded negative translation caching and parser fuzz/regression coverage.
 
 ### Changed
 
@@ -29,6 +32,8 @@ All notable project changes are documented here.
 - Added deterministic per-worker freshness jitter to spread repository checks without extending the configured cache TTL.
 - Unchanged translation SHAs now preserve existing corpora and built search indexes instead of decoding and rebuilding them.
 - Replaced permanently retained keyed locks with reference-counted per-resource coordination.
+- Repository downloads now stream into a finite byte budget and validate path, timeout, retry, and backoff configuration.
+- CI now compiles every source file and runs static security and dependency-advisory scans without removing any existing test or package checks.
 
 ### Fixed
 
@@ -36,6 +41,9 @@ All notable project changes are documented here.
 - Chapter and translation cache updates can no longer replace valid data with partial or checksum-mismatched downloads.
 - PyPI publication no longer runs on every push to `master`.
 - Concurrent cache eviction no longer invalidates active searches, and HTTP sessions can now be released explicitly at worker shutdown.
+- Verse ranges are bounded before `range()` is materialized, closing a remote memory-exhaustion path.
+- Reversed and malformed ranges fail closed instead of returning a different verse.
+- Cached `BookReference.verses` lists can no longer be mutated by callers.
 
 ## [1.1.2] - 2023-12-11
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include AGENTS.md
 include CHANGELOG.md
 include LICENSE
 include README.md
+include SECURITY.md
 include requirements.txt
 include requirements-dev.txt
 recursive-include benchmarks *.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security policy
+
+## Supported code
+
+Security fixes are developed on `staging`, validated by the complete CI matrix, and released through the documented release workflow. Production users should run the newest published release and use finite cache, request, and repository limits.
+
+## Reporting a vulnerability
+
+Do not open a public issue containing exploit details, credentials, private data, or a proof of concept that could harm a running service. Use GitHub private vulnerability reporting when available, or contact `getbible@vdm.io` with:
+
+- the affected version or commit;
+- the smallest safe reproduction;
+- expected and observed behavior;
+- impact and any known mitigations.
+
+Never include a Telegram token or other production secret. Rotate a secret immediately if it may have been exposed.
+
+## Security invariants
+
+A change must not remove or bypass these controls:
+
+- references are fully validated and bounded before verse ranges are materialized;
+- one call has finite reference, verse, query, cache, timeout, retry, and response-size budgets;
+- malformed input never silently resolves to a different verse;
+- repository paths remain inside the configured source root;
+- remote requests use explicit connect/read timeouts and bounded retries;
+- raw repository or internal exceptions are not intended as end-user messages;
+- deterministic tests, package checks, Bandit, and dependency auditing remain required CI gates.

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -1,0 +1,53 @@
+# Hardening and request budgets
+
+`GetBible` now applies a fail-closed layer before the existing retrieval and search implementation. Existing result dictionaries and JSON output remain unchanged; only malformed, excessive, or unsafe requests are rejected earlier with typed exceptions.
+
+## Default request limits
+
+```python
+from getbible import GetBible, RequestLimits
+
+bible = GetBible(
+    request_limits=RequestLimits(
+        max_input_length=1024,
+        max_references=8,
+        max_verses_per_reference=200,
+        max_total_verses=200,
+        max_search_offset=10_000,
+        max_search_books=83,
+        max_search_exclusions=32,
+    ),
+    request_timeout=(3.05, 30.0),
+    request_retries=3,
+    max_response_bytes=128 * 1024 * 1024,
+)
+```
+
+The parser has an independent hard ceiling of 200 verses per reference and validates the range size before constructing it. A service may configure stricter values. Public chat and HTTP layers should normally do so.
+
+Legacy open forms such as `John 1:2-` and `John 1:-5` retain their established single-verse meaning. Reversed ranges, zero, malformed punctuation, and ranges above the configured ceiling are rejected.
+
+## Typed failures
+
+- `ReferenceValidationError`: malformed or unresolved reference; remains a `ValueError`.
+- `RequestLimitError`: input exceeded a finite work budget; remains a `ValueError`.
+- `TranslationNotFoundError`: missing translation; remains a `FileNotFoundError`.
+- `RepositoryTimeoutError`: connect or read deadline exceeded.
+- `RepositoryResponseTooLarge`: declared or streamed content exceeded the byte cap.
+- `RepositoryError`: other repository access failures.
+
+Applications should map these classes to stable public messages and log unexpected exceptions with a correlation identifier. They should never echo raw exception strings to untrusted users.
+
+## Translation validation
+
+Positive translation data uses the existing bounded book cache. Missing translations use a separate bounded TTL cache so repeated invalid identifiers do not repeatedly reach the repository. Translation codes still require a complete match of the established identifier grammar.
+
+## Repository boundary
+
+Both local and HTTP resources are byte-bounded. Remote responses are streamed in 64 KiB chunks; `Content-Length` is checked when present, and the cumulative body length is always enforced. Relative paths reject absolute paths, traversal components, unsafe separators, and unsupported characters.
+
+Use HTTPS for remote production repositories. Plain HTTP remains supported for loopback tests and explicitly controlled private deployments for backward compatibility.
+
+## Application-layer requirements
+
+The library limits protect every caller, but public applications must additionally provide identity-aware rate limiting, bounded concurrency, an outer operation deadline, safe output encoding, generic error messages, and deployment resource limits.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,11 @@
 - [Usage and public retrieval API](USAGE.md)
 - [Search API and result contract](SEARCH.md)
 - [Separate Query and Search HTTP integration](API_INTEGRATION.md)
+- [Hardening and request budgets](HARDENING.md)
 - [Caching and SHA validation](CACHING.md)
 - [Internal architecture](ARCHITECTURE.md)
 - [Multi-worker operations](OPERATIONS.md)
+- [Security and reliability release gate](RELEASE_GATE.md)
 - [Development, CI, and releases](RELEASING.md)
 
 Repository-wide instructions for coding agents are in [`AGENTS.md`](../AGENTS.md).

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -1,0 +1,34 @@
+# Security and reliability release gate
+
+A staging commit is releasable only when every item below passes without suppressing or deleting an existing assertion.
+
+## Automated gate
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m compileall -q src tests
+python -m unittest discover -s tests -v
+ruff check src tests benchmarks scripts examples
+bandit -q -r src/getbible -x src/getbible/data
+python -m pip_audit
+python -m build
+python -m twine check dist/*
+```
+
+CI runs deterministic tests on Python 3.10 through 3.14, then installs and imports the built wheel in an isolated environment. Live API integration remains a separate opt-in workflow so the deterministic gate cannot be made flaky by an external service.
+
+## Required adversarial cases
+
+- a range such as `John 1:1-999999999` terminates without proportional allocation;
+- malformed or reversed ranges never resolve to verse 1 or another unintended verse;
+- per-reference and aggregate verse budgets are both enforced;
+- repeated missing translations use bounded negative caching;
+- oversized local and remote repository bodies are rejected;
+- repository traversal is rejected;
+- blank and excessive search inputs fail before translation loading;
+- cache entries cannot be corrupted through a returned mutable verse list;
+- all historical parser, Unicode, search, cache, local/HTTP parity, and packaging tests still pass.
+
+## Operational gate
+
+Before deployment, verify explicit memory and task limits, restart behavior, secret-file permissions, log redaction, metrics collection, rollback to the previous release, and a bounded outage response when the upstream repository is unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,11 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-  "build>=1.2",
-  "ruff>=0.8",
-  "twine>=5",
+  "bandit>=1.7,<2",
+  "build>=1.2,<2",
+  "pip-audit>=2.7,<3",
+  "ruff>=0.8,<1",
+  "twine>=5,<7",
 ]
 
 [project.urls]
@@ -67,3 +69,6 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["B011"]
 "tests/test_getbible*.py" = ["E501"]
+
+[tool.bandit]
+exclude_dirs = ["tests", "src/getbible/data"]

--- a/src/getbible/__init__.py
+++ b/src/getbible/__init__.py
@@ -1,14 +1,19 @@
 from .exceptions import (
     CacheIntegrityError,
     GetBibleError,
+    ReferenceValidationError,
     RepositoryError,
     RepositoryResourceNotFound,
     RepositoryResponseError,
+    RepositoryResponseTooLarge,
+    RepositoryTimeoutError,
+    RequestLimitError,
     SearchValidationError,
+    TranslationNotFoundError,
 )
-from .getbible import GetBible
 from .getbible_book_number import GetBibleBookNumber
 from .getbible_reference import BookReference, GetBibleReference
+from .hardened import GetBible, RequestLimits
 from .search import SearchBible, SearchCriteria
 
 __all__ = [
@@ -18,10 +23,16 @@ __all__ = [
     "GetBibleBookNumber",
     "GetBibleError",
     "GetBibleReference",
+    "ReferenceValidationError",
     "RepositoryError",
     "RepositoryResourceNotFound",
     "RepositoryResponseError",
-    "SearchValidationError",
+    "RepositoryResponseTooLarge",
+    "RepositoryTimeoutError",
+    "RequestLimitError",
+    "RequestLimits",
     "SearchBible",
     "SearchCriteria",
+    "SearchValidationError",
+    "TranslationNotFoundError",
 ]

--- a/src/getbible/exceptions.py
+++ b/src/getbible/exceptions.py
@@ -5,8 +5,24 @@ class GetBibleError(Exception):
     """Base exception for Librarian-specific failures."""
 
 
+class ReferenceValidationError(ValueError, GetBibleError):
+    """Raised when a scripture reference is malformed or cannot be resolved."""
+
+
+class RequestLimitError(ReferenceValidationError):
+    """Raised when otherwise valid input exceeds a configured work budget."""
+
+
+class TranslationNotFoundError(FileNotFoundError, GetBibleError):
+    """Raised when a requested translation is not available."""
+
+
 class RepositoryError(GetBibleError):
     """Raised when the configured scripture repository cannot be read."""
+
+
+class RepositoryTimeoutError(RepositoryError):
+    """Raised when a repository request exceeds its connect or read timeout."""
 
 
 class RepositoryResourceNotFound(RepositoryError):
@@ -15,6 +31,10 @@ class RepositoryResourceNotFound(RepositoryError):
 
 class RepositoryResponseError(RepositoryError):
     """Raised when a repository response is malformed or cannot be decoded."""
+
+
+class RepositoryResponseTooLarge(RepositoryResponseError):
+    """Raised before an oversized repository response can exhaust memory."""
 
 
 class CacheIntegrityError(GetBibleError):

--- a/src/getbible/getbible.py
+++ b/src/getbible/getbible.py
@@ -478,7 +478,7 @@ class GetBible:
             loaded = _CacheEntry(
                 data=chapter_data,
                 loaded_at=time.monotonic(),
-                sha=hashlib.sha1(raw).hexdigest(),
+                sha=hashlib.sha1(raw, usedforsecurity=False).hexdigest(),
             )
             with self._cache_guard:
                 self._put_bounded(

--- a/src/getbible/getbible_reference.py
+++ b/src/getbible/getbible_reference.py
@@ -7,6 +7,7 @@ import unicodedata
 from collections import OrderedDict
 from dataclasses import dataclass
 
+from .exceptions import ReferenceValidationError, RequestLimitError
 from .getbible_book_number import GetBibleBookNumber
 
 
@@ -19,17 +20,36 @@ class BookReference:
 
 
 class GetBibleReference:
-    """Resolve human scripture references into canonical book coordinates."""
+    """Resolve human scripture references into canonical book coordinates.
+
+    Parsing is deliberately bounded before any range is materialized.  The
+    defaults cover every canonical Bible chapter while preventing an attacker
+    from turning a reference into an arbitrarily large Python list.
+    """
 
     _ALLOWED_PUNCTUATION = frozenset(" ,:-.'’")
 
-    def __init__(self, cache_limit: int | None = 5000) -> None:
+    def __init__(
+        self,
+        cache_limit: int | None = 5000,
+        *,
+        max_reference_length: int = 100,
+        max_verses: int = 200,
+        max_verse_number: int = 1000,
+    ) -> None:
         if cache_limit is not None and (
             not isinstance(cache_limit, int)
             or isinstance(cache_limit, bool)
             or cache_limit < 0
         ):
             raise ValueError("cache_limit must be a non-negative integer or null.")
+        self.__max_reference_length = self.__positive_limit(
+            "max_reference_length", max_reference_length
+        )
+        self.__max_verses = self.__positive_limit("max_verses", max_verses)
+        self.__max_verse_number = self.__positive_limit(
+            "max_verse_number", max_verse_number
+        )
         self.__get_book = GetBibleBookNumber()
         self.__cache: OrderedDict[tuple[str, str], BookReference | None] = OrderedDict()
         self.__cache_limit = cache_limit
@@ -39,10 +59,10 @@ class GetBibleReference:
         self.__cache_evictions = 0
 
     def ref(self, reference: str, translation_code: str | None = None) -> BookReference:
-        """Return a parsed reference or raise :class:`ValueError`."""
+        """Return a parsed reference or raise a typed validation exception."""
         normalized = self.__sanitize(reference)
         if normalized is None:
-            raise ValueError(f"Invalid reference '{reference}'.")
+            raise ReferenceValidationError(f"Invalid reference '{reference}'.")
 
         key = ((translation_code or "").casefold(), normalized.casefold())
         with self.__cache_guard:
@@ -65,15 +85,21 @@ class GetBibleReference:
                     self.__manage_local_cache(key, cached)
 
         if cached is None:
-            raise ValueError(f"Invalid reference '{reference}'.")
-        return cached
+            raise ReferenceValidationError(f"Invalid reference '{reference}'.")
+        # Do not expose the mutable list held by the cache to callers.
+        return BookReference(
+            book=cached.book,
+            chapter=cached.chapter,
+            verses=list(cached.verses),
+            reference=cached.reference,
+        )
 
     def valid(self, reference: str, translation_code: str | None = None) -> bool:
-        """Return whether ``reference`` can be resolved."""
+        """Return whether ``reference`` can be resolved within configured limits."""
         try:
             self.ref(reference, translation_code)
             return True
-        except ValueError:
+        except ReferenceValidationError:
             return False
 
     def book_number(
@@ -83,7 +109,7 @@ class GetBibleReference:
         return self.__get_book.number(reference, translation_code)
 
     def cache_info(self) -> dict[str, int | None]:
-        """Return reference-cache size, limit, and counters."""
+        """Return reference-cache size, limits, and counters."""
         with self.__cache_guard:
             return {
                 "size": len(self.__cache),
@@ -91,13 +117,20 @@ class GetBibleReference:
                 "hits": self.__cache_hits,
                 "misses": self.__cache_misses,
                 "evictions": self.__cache_evictions,
+                "max_reference_length": self.__max_reference_length,
+                "max_verses": self.__max_verses,
+                "max_verse_number": self.__max_verse_number,
             }
 
     def __sanitize(self, reference: str) -> str | None:
         if not isinstance(reference, str):
             return None
         normalized = unicodedata.normalize("NFC", reference.strip())
-        if not normalized or len(normalized) > 100 or normalized.count(":") > 1:
+        if (
+            not normalized
+            or len(normalized) > self.__max_reference_length
+            or normalized.count(":") > 1
+        ):
             return None
 
         for character in normalized:
@@ -135,7 +168,7 @@ class GetBibleReference:
 
     @staticmethod
     def __split_reference(reference: str) -> tuple[str, str]:
-        return reference.split(':', 1) if ':' in reference else (reference, '1')
+        return reference.split(":", 1) if ":" in reference else (reference, "1")
 
     @staticmethod
     def __extract_chapter(book_chapter: str) -> int | None:
@@ -158,40 +191,83 @@ class GetBibleReference:
             index -= 1
         return book_chapter[:index].strip() if index < len(book_chapter) else book_chapter.strip()
 
-    @staticmethod
-    def __get_verses_numbers(verses: str) -> list[int] | None:
+    def __get_verses_numbers(self, verses: str) -> list[int] | None:
         if not verses:
             return [1]
 
         verse_list: list[int] = []
-        for part in verses.split(','):
+        seen: set[int] = set()
+        for part in verses.split(","):
             part = part.strip()
             if not part:
                 return None
-            if '-' not in part:
-                if not part.isdigit() or int(part) < 1:
+            if "-" not in part:
+                if not part.isdigit():
                     return None
-                verse_list.append(int(part))
+                verse = int(part)
+                if verse < 1:
+                    return None
+                if verse > self.__max_verse_number:
+                    raise RequestLimitError(
+                        f"Verse numbers cannot exceed {self.__max_verse_number}."
+                    )
+                self.__append_bounded(verse_list, seen, verse)
                 continue
 
-            if part.count('-') != 1:
+            if part.count("-") != 1:
                 return None
-            start_text, end_text = part.split('-', 1)
+            start_text, end_text = part.split("-", 1)
             if start_text and end_text:
                 if not start_text.isdigit() or not end_text.isdigit():
                     return None
-                start, end = sorted((int(start_text), int(end_text)))
-                if start < 1:
+                start = int(start_text)
+                end = int(end_text)
+                if start < 1 or end < 1 or start > end:
                     return None
-                verse_list.extend(range(start, end + 1))
-            elif start_text.isdigit() and int(start_text) > 0:
-                verse_list.append(int(start_text))
-            elif end_text.isdigit() and int(end_text) > 0:
-                verse_list.append(int(end_text))
+                if start > self.__max_verse_number or end > self.__max_verse_number:
+                    raise RequestLimitError(
+                        f"Verse numbers cannot exceed {self.__max_verse_number}."
+                    )
+                range_size = end - start + 1
+                if range_size > self.__max_verses or len(seen) + range_size > self.__max_verses:
+                    raise RequestLimitError(
+                        f"A reference cannot select more than {self.__max_verses} verses."
+                    )
+                # The range is known to be bounded before it is materialized.
+                for verse in range(start, end + 1):
+                    self.__append_bounded(verse_list, seen, verse)
+            elif start_text.isdigit():
+                verse = int(start_text)
+                if verse < 1:
+                    return None
+                if verse > self.__max_verse_number:
+                    raise RequestLimitError(
+                        f"Verse numbers cannot exceed {self.__max_verse_number}."
+                    )
+                self.__append_bounded(verse_list, seen, verse)
+            elif end_text.isdigit():
+                verse = int(end_text)
+                if verse < 1:
+                    return None
+                if verse > self.__max_verse_number:
+                    raise RequestLimitError(
+                        f"Verse numbers cannot exceed {self.__max_verse_number}."
+                    )
+                self.__append_bounded(verse_list, seen, verse)
             else:
                 return None
 
-        return list(dict.fromkeys(verse_list)) if verse_list else None
+        return verse_list if verse_list else None
+
+    def __append_bounded(self, values: list[int], seen: set[int], verse: int) -> None:
+        if verse in seen:
+            return
+        if len(seen) >= self.__max_verses:
+            raise RequestLimitError(
+                f"A reference cannot select more than {self.__max_verses} verses."
+            )
+        seen.add(verse)
+        values.append(verse)
 
     def __manage_local_cache(
         self,
@@ -200,10 +276,15 @@ class GetBibleReference:
     ) -> None:
         if self.__cache_limit == 0:
             return
-        if (
-            self.__cache_limit is not None
-            and len(self.__cache) >= self.__cache_limit
-        ):
+        if self.__cache_limit is not None and len(self.__cache) >= self.__cache_limit:
             self.__cache.popitem(last=False)
             self.__cache_evictions += 1
         self.__cache[key] = value
+
+    @staticmethod
+    def __positive_limit(name: str, value: int) -> int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise TypeError(f"{name} must be an integer.")
+        if value < 1:
+            raise ValueError(f"{name} must be positive.")
+        return value

--- a/src/getbible/hardened.py
+++ b/src/getbible/hardened.py
@@ -1,0 +1,292 @@
+"""Fail-closed public facade with request-level resource budgets."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+from typing import Any
+
+from ._keyed_locks import KeyedLockPool
+from .exceptions import (
+    ReferenceValidationError,
+    RequestLimitError,
+    SearchValidationError,
+    TranslationNotFoundError,
+)
+from .getbible import GetBible as _BaseGetBible
+from .search import SearchBible
+
+
+@dataclass(frozen=True, slots=True)
+class RequestLimits:
+    """Per-call work budgets enforced before repository access."""
+
+    max_input_length: int = 1024
+    max_references: int = 8
+    max_verses_per_reference: int = 200
+    max_total_verses: int = 200
+    max_search_offset: int = 10_000
+    max_search_books: int = 83
+    max_search_exclusions: int = 32
+
+    def __post_init__(self) -> None:
+        for name, value in asdict(self).items():
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"{name} must be an integer.")
+            if value < 1:
+                raise ValueError(f"{name} must be positive.")
+        # The parser applies this hard ceiling before materializing a range.
+        if self.max_verses_per_reference > 200:
+            raise ValueError("max_verses_per_reference cannot exceed the parser ceiling of 200.")
+
+
+class GetBible(_BaseGetBible):
+    """The public Librarian client with bounded parsing and typed failures.
+
+    Existing retrieval and search response contracts are preserved. Added
+    limits reject abusive input before network or cache work is performed.
+    """
+
+    def __init__(
+        self,
+        repo_path: str | os.PathLike[str] = "https://api.getbible.net",
+        version: str = "v2",
+        cache_ttl: timedelta = timedelta(days=7),
+        request_timeout: tuple[float, float] = (3.05, 30.0),
+        request_retries: int = 3,
+        cache_dir: str | os.PathLike[str] | None = None,
+        strict_freshness: bool = False,
+        reference_cache_limit: int | None = 5000,
+        books_cache_limit: int | None = 64,
+        chapter_cache_limit: int | None = 2048,
+        search_corpus_limit: int | None = 4,
+        translation_cache_limit: int | None = 4,
+        cache_ttl_jitter: float = 0.1,
+        *,
+        request_limits: RequestLimits | None = None,
+        negative_translation_cache_limit: int = 64,
+        negative_translation_ttl: float = 300.0,
+        max_response_bytes: int = 128 * 1024 * 1024,
+    ) -> None:
+        self.request_limits = request_limits or RequestLimits()
+        self._negative_translation_cache_limit = self._bounded_integer(
+            "negative_translation_cache_limit",
+            negative_translation_cache_limit,
+            minimum=1,
+            maximum=10_000,
+        )
+        self._negative_translation_ttl = self._bounded_float(
+            "negative_translation_ttl",
+            negative_translation_ttl,
+            minimum=1.0,
+            maximum=86_400.0,
+        )
+        super().__init__(
+            repo_path=repo_path,
+            version=version,
+            cache_ttl=cache_ttl,
+            request_timeout=request_timeout,
+            request_retries=request_retries,
+            cache_dir=cache_dir,
+            strict_freshness=strict_freshness,
+            reference_cache_limit=reference_cache_limit,
+            books_cache_limit=books_cache_limit,
+            chapter_cache_limit=chapter_cache_limit,
+            search_corpus_limit=search_corpus_limit,
+            translation_cache_limit=translation_cache_limit,
+            cache_ttl_jitter=cache_ttl_jitter,
+        )
+        self._repository.max_response_bytes = self._bounded_integer(
+            "max_response_bytes",
+            max_response_bytes,
+            minimum=1,
+            maximum=1024**3,
+        )
+        self._missing_translations: OrderedDict[str, float] = OrderedDict()
+        self._missing_translations_guard = threading.Lock()
+        self._translation_validation_locks = KeyedLockPool()
+        self._negative_translation_hits = 0
+        self._negative_translation_misses = 0
+        self._negative_translation_evictions = 0
+
+    def select(self, reference: str, abbreviation: str | None = "kjv") -> dict[str, Any]:
+        """Return verses after enforcing reference and total-work limits."""
+        code = self._validated_translation_code(abbreviation)
+        self._validated_references(reference, code)
+        if not self.valid_translation(code):
+            raise TranslationNotFoundError(f"Translation ({code}) not found.")
+        try:
+            return super().select(reference, code)
+        except ReferenceValidationError:
+            raise
+        except ValueError as error:
+            raise ReferenceValidationError(str(error)) from error
+
+    def valid_reference(self, reference: str, abbreviation: str | None = "kjv") -> bool:
+        """Return whether one bounded reference is structurally resolvable."""
+        if not isinstance(reference, str) or len(reference) > self.request_limits.max_input_length:
+            return False
+        return super().valid_reference(reference, abbreviation)
+
+    def valid_translation(self, abbreviation: str) -> bool:
+        """Validate a translation with a bounded negative-result TTL cache."""
+        try:
+            code = self._validated_translation_code(abbreviation)
+        except (TypeError, ValueError):
+            return False
+
+        if self._negative_translation_cached(code):
+            return False
+        with self._translation_validation_locks.hold(code):
+            if self._negative_translation_cached(code):
+                return False
+            available = super().valid_translation(code)
+            if available:
+                with self._missing_translations_guard:
+                    self._missing_translations.pop(code, None)
+                return True
+            self._remember_missing_translation(code)
+            return False
+
+    def search(
+        self,
+        query: str,
+        abbreviation: str | None = "kjv",
+        criteria: SearchBible | dict[str, Any] | str | None = None,
+    ) -> dict[str, Any]:
+        """Search only after cheap input and criteria checks have passed."""
+        if not isinstance(query, str):
+            raise SearchValidationError("Search query must be a string.")
+        stripped_query = query.strip()
+        if not stripped_query:
+            raise SearchValidationError("Search query cannot be empty.")
+        if len(stripped_query) > 500:
+            raise RequestLimitError("Search query cannot exceed 500 characters.")
+        parsed = SearchBible.from_value(criteria)
+        if parsed.offset > self.request_limits.max_search_offset:
+            raise RequestLimitError(
+                f"Search offset cannot exceed {self.request_limits.max_search_offset}."
+            )
+        if len(parsed.books) > self.request_limits.max_search_books:
+            raise RequestLimitError(
+                f"Search cannot select more than {self.request_limits.max_search_books} books."
+            )
+        if len(parsed.exclude) > self.request_limits.max_search_exclusions:
+            raise RequestLimitError(
+                "Search cannot contain more than "
+                f"{self.request_limits.max_search_exclusions} exclusions."
+            )
+        return super().search(stripped_query, abbreviation, parsed)
+
+    def cache_info(self) -> dict[str, Any]:
+        """Return base telemetry plus request and negative-cache limits."""
+        state = super().cache_info()
+        now = time.monotonic()
+        with self._missing_translations_guard:
+            self._purge_expired_missing(now)
+            state["negative_translations"] = {
+                "size": len(self._missing_translations),
+                "limit": self._negative_translation_cache_limit,
+                "ttl_seconds": self._negative_translation_ttl,
+                "hits": self._negative_translation_hits,
+                "misses": self._negative_translation_misses,
+                "evictions": self._negative_translation_evictions,
+            }
+        state["request_limits"] = asdict(self.request_limits)
+        state["active_translation_validation_locks"] = self._translation_validation_locks.size
+        state["repository_max_response_bytes"] = self._repository.max_response_bytes
+        return state
+
+    def close(self) -> None:
+        with self._missing_translations_guard:
+            self._missing_translations.clear()
+        super().close()
+
+    def _validated_references(self, reference: str, abbreviation: str) -> None:
+        if not isinstance(reference, str):
+            raise ReferenceValidationError("Scripture reference must be a string.")
+        if len(reference) > self.request_limits.max_input_length:
+            raise RequestLimitError(
+                f"Reference input cannot exceed {self.request_limits.max_input_length} characters."
+            )
+        references = reference.split(";")
+        if len(references) > self.request_limits.max_references:
+            raise RequestLimitError(
+                "A request cannot contain more than "
+                f"{self.request_limits.max_references} references."
+            )
+
+        total_verses = 0
+        parser = self._GetBible__get
+        for raw_reference in references:
+            item = raw_reference.strip()
+            if not item:
+                raise ReferenceValidationError("Invalid empty reference.")
+            parsed = parser.ref(item, abbreviation)
+            selected = len(parsed.verses)
+            if selected > self.request_limits.max_verses_per_reference:
+                raise RequestLimitError(
+                    "A reference cannot select more than "
+                    f"{self.request_limits.max_verses_per_reference} verses."
+                )
+            total_verses += selected
+            if total_verses > self.request_limits.max_total_verses:
+                raise RequestLimitError(
+                    "A request cannot select more than "
+                    f"{self.request_limits.max_total_verses} verses."
+                )
+
+    def _negative_translation_cached(self, code: str) -> bool:
+        now = time.monotonic()
+        with self._missing_translations_guard:
+            self._purge_expired_missing(now)
+            expires_at = self._missing_translations.get(code)
+            if expires_at is None:
+                self._negative_translation_misses += 1
+                return False
+            self._missing_translations.move_to_end(code)
+            self._negative_translation_hits += 1
+            return expires_at > now
+
+    def _remember_missing_translation(self, code: str) -> None:
+        expires_at = time.monotonic() + self._negative_translation_ttl
+        with self._missing_translations_guard:
+            self._missing_translations[code] = expires_at
+            self._missing_translations.move_to_end(code)
+            while len(self._missing_translations) > self._negative_translation_cache_limit:
+                self._missing_translations.popitem(last=False)
+                self._negative_translation_evictions += 1
+
+    def _purge_expired_missing(self, now: float) -> None:
+        expired = [
+            code for code, expires_at in self._missing_translations.items() if expires_at <= now
+        ]
+        for code in expired:
+            self._missing_translations.pop(code, None)
+
+    @staticmethod
+    def _bounded_integer(name: str, value: int, *, minimum: int, maximum: int) -> int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise TypeError(f"{name} must be an integer.")
+        if not minimum <= value <= maximum:
+            raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+        return value
+
+    @staticmethod
+    def _bounded_float(
+        name: str,
+        value: float,
+        *,
+        minimum: float,
+        maximum: float,
+    ) -> float:
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            raise TypeError(f"{name} must be numeric.")
+        numeric = float(value)
+        if not minimum <= numeric <= maximum:
+            raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+        return numeric

--- a/src/getbible/repository_client.py
+++ b/src/getbible/repository_client.py
@@ -1,11 +1,12 @@
-"""Reliable access to remote and local GetBible API-compatible repositories."""
+"""Reliable, bounded access to GetBible API-compatible repositories."""
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import threading
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import requests
@@ -16,64 +17,67 @@ from .exceptions import (
     RepositoryError,
     RepositoryResourceNotFound,
     RepositoryResponseError,
+    RepositoryResponseTooLarge,
+    RepositoryTimeoutError,
 )
 
 
 class RepositoryClient:
-    """Read bytes, text, and JSON from an API v2-compatible repository.
+    """Read bytes, text, and JSON from a repository with finite resource use.
 
     A thread-local :class:`requests.Session` keeps connection pooling efficient
     without sharing mutable ``Session`` state between application threads.
+    Remote and local responses are size-bounded before their content is returned.
     """
+
+    DEFAULT_MAX_RESPONSE_BYTES = 128 * 1024 * 1024
+    _SAFE_SEGMENT = re.compile(r"[A-Za-z0-9._-]+")
 
     def __init__(
         self,
         repo_path: str | os.PathLike[str] = "https://api.getbible.net",
         version: str = "v2",
-        timeout: tuple[float, float] = (3.05, 60.0),
+        timeout: tuple[float, float] = (3.05, 30.0),
         retries: int = 3,
         backoff_factor: float = 0.25,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
     ) -> None:
-        source = os.fspath(repo_path)
+        try:
+            source = os.fspath(repo_path)
+        except TypeError as error:
+            raise TypeError("repo_path must be a string or path-like value.") from error
+        if not source.strip():
+            raise ValueError("repo_path cannot be empty.")
+
+        self.timeout = self._validated_timeout(timeout)
+        self.retries = self._bounded_integer("retries", retries, minimum=0, maximum=10)
+        self.backoff_factor = self._bounded_float(
+            "backoff_factor", backoff_factor, minimum=0.0, maximum=60.0
+        )
+        self.max_response_bytes = self._bounded_integer(
+            "max_response_bytes", max_response_bytes, minimum=1, maximum=1024**3
+        )
+
+        clean_version = version.strip("/") if isinstance(version, str) else ""
+        if not clean_version or self._SAFE_SEGMENT.fullmatch(clean_version) is None:
+            raise ValueError("version must contain only letters, numbers, '.', '_', or '-'.")
+        self.version = clean_version
+
         if source.startswith(("http://", "https://")):
             self.repo_path = source.rstrip("/")
         else:
             self.repo_path = os.path.normpath(os.path.expanduser(source))
-        self.version = version.strip("/")
-        self.timeout = timeout
-        self.retries = retries
-        self.backoff_factor = backoff_factor
         self.is_url = self.repo_path.startswith(("http://", "https://"))
         self._thread_local = threading.local()
         self._sessions: set[requests.Session] = set()
         self._sessions_guard = threading.Lock()
 
     def fetch_bytes(self, relative_path: str) -> bytes:
-        """Return a repository resource as bytes."""
+        """Return a repository resource as bytes within the configured size cap."""
+        clean_relative = self._validated_relative_path(relative_path)
         if self.is_url:
-            url = self.location(relative_path)
-            try:
-                response = self._session().get(url, timeout=self.timeout)
-            except requests.RequestException as error:
-                raise RepositoryError(f"Unable to fetch {url}: {error}") from error
-
-            if response.status_code == 404:
-                raise RepositoryResourceNotFound(f"Repository resource not found: {url}")
-            try:
-                response.raise_for_status()
-            except requests.RequestException as error:
-                raise RepositoryError(f"Unable to fetch {url}: {error}") from error
-            return response.content
-
-        path = Path(self.location(relative_path))
-        try:
-            return path.read_bytes()
-        except FileNotFoundError as error:
-            raise RepositoryResourceNotFound(
-                f"Repository resource not found: {path}"
-            ) from error
-        except OSError as error:
-            raise RepositoryError(f"Unable to read {path}: {error}") from error
+            return self._fetch_remote(clean_relative)
+        return self._fetch_local(clean_relative)
 
     def fetch_text(self, relative_path: str) -> str:
         """Return a UTF-8 repository resource as text."""
@@ -100,18 +104,18 @@ class RepositoryClient:
         return value
 
     def location(self, relative_path: str) -> str:
-        """Return the URL or local path for a relative API resource."""
-        clean_relative = relative_path.lstrip("/")
+        """Return the URL or local path for a validated relative API resource."""
+        clean_relative = self._validated_relative_path(relative_path)
         if self.is_url:
             return f"{self.repo_path}/{self.version}/{clean_relative}"
-        return os.path.join(self.repo_path, self.version, clean_relative)
+        root = (Path(self.repo_path) / self.version).resolve()
+        candidate = (root / clean_relative).resolve()
+        if candidate != root and root not in candidate.parents:
+            raise RepositoryError("Repository resource escaped the configured root.")
+        return str(candidate)
 
     def close(self) -> None:
-        """Close every HTTP session created by this client.
-
-        Call this only during worker or application shutdown, after request
-        threads have stopped using the client.
-        """
+        """Close every HTTP session created by this client."""
         with self._sessions_guard:
             sessions = tuple(self._sessions)
             self._sessions.clear()
@@ -120,6 +124,65 @@ class RepositoryClient:
         for name in ("session", "process_id"):
             if hasattr(self._thread_local, name):
                 delattr(self._thread_local, name)
+
+    def _fetch_remote(self, relative_path: str) -> bytes:
+        url = self.location(relative_path)
+        response: requests.Response | None = None
+        try:
+            response = self._session().get(url, timeout=self.timeout, stream=True)
+            if response.status_code == 404:
+                raise RepositoryResourceNotFound(f"Repository resource not found: {url}")
+            response.raise_for_status()
+            declared_size = response.headers.get("Content-Length")
+            if declared_size is not None:
+                try:
+                    content_length = int(declared_size)
+                except ValueError:
+                    content_length = -1
+                if content_length > self.max_response_bytes:
+                    raise RepositoryResponseTooLarge(
+                        f"Repository response exceeds {self.max_response_bytes} bytes: {url}"
+                    )
+
+            chunks: list[bytes] = []
+            size = 0
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                size += len(chunk)
+                if size > self.max_response_bytes:
+                    raise RepositoryResponseTooLarge(
+                        f"Repository response exceeds {self.max_response_bytes} bytes: {url}"
+                    )
+                chunks.append(chunk)
+            return b"".join(chunks)
+        except requests.Timeout as error:
+            raise RepositoryTimeoutError(f"Repository request timed out: {url}") from error
+        except RepositoryError:
+            raise
+        except requests.RequestException as error:
+            raise RepositoryError(f"Unable to fetch {url}: {error}") from error
+        finally:
+            if response is not None:
+                response.close()
+
+    def _fetch_local(self, relative_path: str) -> bytes:
+        path = Path(self.location(relative_path))
+        try:
+            size = path.stat().st_size
+            if size > self.max_response_bytes:
+                raise RepositoryResponseTooLarge(
+                    f"Repository response exceeds {self.max_response_bytes} bytes: {path}"
+                )
+            return path.read_bytes()
+        except RepositoryError:
+            raise
+        except FileNotFoundError as error:
+            raise RepositoryResourceNotFound(
+                f"Repository resource not found: {path}"
+            ) from error
+        except OSError as error:
+            raise RepositoryError(f"Unable to read {path}: {error}") from error
 
     def _session(self) -> requests.Session:
         process_id = os.getpid()
@@ -141,10 +204,16 @@ class RepositoryClient:
             status_forcelist=(429, 500, 502, 503, 504),
             allowed_methods=frozenset({"GET"}),
             raise_on_status=False,
+            respect_retry_after_header=True,
         )
         adapter = HTTPAdapter(max_retries=retry, pool_connections=20, pool_maxsize=20)
         session = requests.Session()
-        session.headers.update({"User-Agent": "getbible-librarian"})
+        session.headers.update(
+            {
+                "User-Agent": "getbible-librarian/1.2",
+                "Accept": "application/json, text/plain;q=0.9, */*;q=0.1",
+            }
+        )
         session.mount("http://", adapter)
         session.mount("https://", adapter)
         self._thread_local.session = session
@@ -152,3 +221,55 @@ class RepositoryClient:
         with self._sessions_guard:
             self._sessions.add(session)
         return session
+
+    @classmethod
+    def _validated_relative_path(cls, relative_path: str) -> str:
+        if not isinstance(relative_path, str):
+            raise TypeError("relative_path must be a string.")
+        candidate = relative_path.strip().replace("\\", "/")
+        path = PurePosixPath(candidate)
+        if (
+            not candidate
+            or candidate in {".", ".."}
+            or candidate.startswith("/")
+            or path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or any(cls._SAFE_SEGMENT.fullmatch(part) is None for part in path.parts)
+        ):
+            raise ValueError("relative_path must be a safe repository-relative path.")
+        return path.as_posix()
+
+    @staticmethod
+    def _validated_timeout(value: tuple[float, float]) -> tuple[float, float]:
+        if not isinstance(value, tuple) or len(value) != 2:
+            raise TypeError("timeout must be a (connect, read) tuple.")
+        connect = RepositoryClient._bounded_float(
+            "connect timeout", value[0], minimum=0.001, maximum=300.0
+        )
+        read = RepositoryClient._bounded_float(
+            "read timeout", value[1], minimum=0.001, maximum=300.0
+        )
+        return connect, read
+
+    @staticmethod
+    def _bounded_integer(name: str, value: int, *, minimum: int, maximum: int) -> int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise TypeError(f"{name} must be an integer.")
+        if not minimum <= value <= maximum:
+            raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+        return value
+
+    @staticmethod
+    def _bounded_float(
+        name: str,
+        value: float,
+        *,
+        minimum: float,
+        maximum: float,
+    ) -> float:
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            raise TypeError(f"{name} must be numeric.")
+        numeric = float(value)
+        if not minimum <= numeric <= maximum:
+            raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+        return numeric

--- a/src/getbible/search.py
+++ b/src/getbible/search.py
@@ -16,8 +16,8 @@ import regex
 from .exceptions import CacheIntegrityError, SearchValidationError
 from .translation_cache import TranslationSnapshot
 
-_TOKEN_CLASS = r"\p{L}\p{M}\p{N}"
-_TOKEN = regex.compile(rf"[{_TOKEN_CLASS}]+(?:['’][{_TOKEN_CLASS}]+)*")
+_WORD_CHARACTER_CLASS = r"\p{L}\p{M}\p{N}"
+_TOKEN = regex.compile(rf"[{_WORD_CHARACTER_CLASS}]+(?:['’][{_WORD_CHARACTER_CLASS}]+)*")
 _VALID_WORDS = frozenset({"all", "any", "phrase"})
 _VALID_MATCH = frozenset({"whole_word", "substring"})
 _VALID_SCOPE = frozenset({"bible", "old_testament", "new_testament", "deuterocanon"})
@@ -625,10 +625,10 @@ class _Matcher:
         return False
 
     def _phrase_pattern(self, terms: Sequence[str]) -> regex.Pattern[str]:
-        separator = rf"[^{_TOKEN_CLASS}]+"
+        separator = rf"[^{_WORD_CHARACTER_CLASS}]+"
         body = separator.join(regex.escape(term) for term in terms)
         return regex.compile(
-            rf"(?<![{_TOKEN_CLASS}]){body}(?![{_TOKEN_CLASS}])"
+            rf"(?<![{_WORD_CHARACTER_CLASS}]){body}(?![{_WORD_CHARACTER_CLASS}])"
         )
 
 

--- a/src/getbible/translation_cache.py
+++ b/src/getbible/translation_cache.py
@@ -202,7 +202,7 @@ class TranslationCache:
 
         raw = self.repository.fetch_bytes(f"{abbreviation}.json")
         self._increment("downloads")
-        actual_sha = hashlib.sha1(raw).hexdigest()
+        actual_sha = hashlib.sha1(raw, usedforsecurity=False).hexdigest()
         if remote_sha and actual_sha != remote_sha:
             raise CacheIntegrityError(
                 f"Checksum mismatch for translation {abbreviation}: "
@@ -240,7 +240,7 @@ class TranslationCache:
         except OSError:
             return None
 
-        actual_sha = hashlib.sha1(raw).hexdigest()
+        actual_sha = hashlib.sha1(raw, usedforsecurity=False).hexdigest()
         if actual_sha != expected_sha:
             LOGGER.warning("Ignoring a corrupt Librarian translation cache entry.")
             return None

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,131 @@
+import random
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from getbible import (
+    GetBible,
+    GetBibleReference,
+    ReferenceValidationError,
+    RepositoryResponseTooLarge,
+    RequestLimitError,
+    RequestLimits,
+    SearchValidationError,
+    TranslationNotFoundError,
+)
+from getbible.repository_client import RepositoryClient
+
+FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "repository"
+
+
+class TestReferenceHardening(unittest.TestCase):
+    def setUp(self) -> None:
+        self.references = GetBibleReference()
+
+    def test_large_range_is_rejected_before_materialization(self) -> None:
+        with self.assertRaises(RequestLimitError):
+            self.references.ref("John 1:1-999999999", "kjv")
+
+    def test_reversed_and_malformed_ranges_are_rejected(self) -> None:
+        for reference in ("John 1:10-1", "John 1:16!", "John 1:1--2", "John 1:0"):
+            with (
+                self.subTest(reference=reference),
+                self.assertRaises(ReferenceValidationError),
+            ):
+                self.references.ref(reference, "kjv")
+
+    def test_legacy_open_range_forms_remain_compatible(self) -> None:
+        self.assertEqual(self.references.ref("John 1:2-", "kjv").verses, [2])
+        self.assertEqual(self.references.ref("John 1:-5", "kjv").verses, [5])
+
+    def test_cached_reference_cannot_be_mutated_by_a_caller(self) -> None:
+        first = self.references.ref("John 1:1-3", "kjv")
+        first.verses.append(999)
+        second = self.references.ref("John 1:1-3", "kjv")
+        self.assertEqual(second.verses, [1, 2, 3])
+
+    def test_symbol_fuzz_is_fail_closed(self) -> None:
+        generator = random.Random(20260718)
+        symbols = "!@#$%^&*()[]{}<>?/\\|`~=+\x00\x01\x1f"
+        for _ in range(500):
+            value = "John 1:16" + "".join(generator.choice(symbols) for _ in range(3))
+            self.assertFalse(self.references.valid(value, "kjv"), value)
+
+
+class TestRequestBudgets(unittest.TestCase):
+    def test_reference_count_is_rejected_before_repository_access(self) -> None:
+        bible = GetBible(
+            repo_path="/definitely/not/a/repository",
+            request_limits=RequestLimits(max_references=1),
+        )
+        self.addCleanup(bible.close)
+        with self.assertRaises(RequestLimitError):
+            bible.select("John 1:1;John 1:2", "kjv")
+
+    def test_total_verse_budget_is_enforced(self) -> None:
+        bible = GetBible(
+            repo_path=FIXTURE_REPOSITORY,
+            request_limits=RequestLimits(
+                max_references=2,
+                max_verses_per_reference=3,
+                max_total_verses=5,
+            ),
+        )
+        self.addCleanup(bible.close)
+        with self.assertRaises(RequestLimitError):
+            bible.select("1 1:1-3;1 1:1-3", "test")
+
+    def test_missing_translation_raises_typed_compatible_error(self) -> None:
+        bible = GetBible(repo_path=FIXTURE_REPOSITORY)
+        self.addCleanup(bible.close)
+        with self.assertRaises(TranslationNotFoundError) as raised:
+            bible.select("John 1:1", "missing")
+        self.assertIsInstance(raised.exception, FileNotFoundError)
+
+    def test_negative_translation_results_are_cached(self) -> None:
+        bible = GetBible(repo_path=FIXTURE_REPOSITORY)
+        self.addCleanup(bible.close)
+        with patch(
+            "getbible.hardened._BaseGetBible.valid_translation", return_value=False
+        ) as validate:
+            self.assertFalse(bible.valid_translation("missing"))
+            self.assertFalse(bible.valid_translation("missing"))
+        validate.assert_called_once_with("missing")
+        self.assertEqual(bible.cache_info()["negative_translations"]["size"], 1)
+
+    def test_invalid_search_is_rejected_before_repository_loading(self) -> None:
+        bible = GetBible(repo_path="/definitely/not/a/repository")
+        self.addCleanup(bible.close)
+        with self.assertRaises(SearchValidationError):
+            bible.search("   ", "kjv")
+        with self.assertRaises(RequestLimitError):
+            bible.search("faith", "kjv", {"offset": 10_001})
+
+
+class TestRepositoryBoundaries(unittest.TestCase):
+    def test_local_response_size_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            resource = root / "v2" / "test" / "books.json"
+            resource.parent.mkdir(parents=True)
+            resource.write_bytes(b"{}")
+            client = RepositoryClient(root, max_response_bytes=1)
+            with self.assertRaises(RepositoryResponseTooLarge):
+                client.fetch_bytes("test/books.json")
+
+    def test_repository_paths_cannot_escape_the_root(self) -> None:
+        client = RepositoryClient("/tmp/repository")
+        for path in ("../secret", "/etc/passwd", "test/../../secret"):
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                client.location(path)
+
+    def test_timeout_and_retry_arguments_are_bounded(self) -> None:
+        with self.assertRaises(ValueError):
+            RepositoryClient("/tmp/repository", retries=11)
+        with self.assertRaises(ValueError):
+            RepositoryClient("/tmp/repository", timeout=(0, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bounds reference ranges before materialization, enforces request and repository budgets, adds typed failures and negative translation caching, preserves all historical tests, and strengthens the CI/release gate.