### PR TITLE
Harden production search boundaries and release delivery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,23 +12,78 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  test:
+    name: Python ${{ matrix.python-version }} release gate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: pypi
-
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout frozen source commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'master' || github.ref }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Verify frozen master/tag commit
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            test "${REF_NAME}" = "master"
+          fi
+
+      - name: Run CI test suite
+        run: |
+          python -m compileall -q src tests
+          python -m unittest discover -s tests -v
+
+  build:
+    name: Build immutable distributions
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      release-tag: ${{ steps.release-tag.outputs.tag }}
+    steps:
+      - name: Checkout frozen source commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
           cache: pip
@@ -36,7 +91,7 @@ jobs:
             pyproject.toml
             requirements-dev.txt
 
-      - name: Install development tools
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
@@ -56,28 +111,59 @@ jobs:
           python scripts/check_release_version.py "${RELEASE_TAG}"
           echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
 
-      - name: Run tests
-        run: python -m unittest discover -s tests -v
+      - name: Build once
+        run: |
+          rm -rf build dist *.egg-info
+          python -m build
+          python -m twine check dist/*
+          sha256sum dist/* | tee dist/SHA256SUMS
 
-      - name: Build distributions
-        run: python -m build
+      - name: Attest distributions
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "dist/*"
 
-      - name: Verify distributions
-        run: python -m twine check dist/*
+      - name: Upload immutable distributions
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: getbible-release-${{ github.sha }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish trusted release
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout frozen source commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Download immutable distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: getbible-release-${{ github.sha }}
+          path: dist
 
       - name: Create and push release tag
         if: github.event_name == 'workflow_dispatch'
         env:
-          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+          RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
         run: |
           git fetch --tags origin
           CURRENT_COMMIT="$(git rev-parse HEAD)"
+          test "${CURRENT_COMMIT}" = "${GITHUB_SHA}"
           if git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}"; then
             TAG_COMMIT="$(git rev-list -n 1 "${RELEASE_TAG}")"
-            if [ "${TAG_COMMIT}" != "${CURRENT_COMMIT}" ]; then
-              echo "Tag ${RELEASE_TAG} already points to ${TAG_COMMIT}, not ${CURRENT_COMMIT}." >&2
-              exit 1
-            fi
+            test "${TAG_COMMIT}" = "${CURRENT_COMMIT}"
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -85,13 +171,11 @@ jobs:
             git push origin "${RELEASE_TAG}"
           fi
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # release/v1
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+          RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
         run: gh release create "${RELEASE_TAG}" dist/* --generate-notes --verify-tag

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -1,11 +1,11 @@
 # Hardening and request budgets
 
-`GetBible` now applies a fail-closed layer before the existing retrieval and search implementation. Existing result dictionaries and JSON output remain unchanged; only malformed, excessive, or unsafe requests are rejected earlier with typed exceptions.
+`GetBible` applies a fail-closed layer before retrieval and search. Malformed, excessive, missing-translation, or unsafe requests are rejected before expensive translation-cache and persistent lock paths are entered.
 
-## Default request limits
+## Default request and search limits
 
 ```python
-from getbible import GetBible, RequestLimits
+from getbible import GetBible, RequestLimits, SearchLimits
 
 bible = GetBible(
     request_limits=RequestLimits(
@@ -17,37 +17,52 @@ bible = GetBible(
         max_search_books=83,
         max_search_exclusions=32,
     ),
+    search_limits=SearchLimits(
+        max_query_length=500,
+        min_substring_length=3,
+        max_terms=32,
+        max_exclusion_length=128,
+        max_filter_values=83,
+        max_work_units=500_000,
+        max_response_bytes=8 * 1024 * 1024,
+        deadline_seconds=10.0,
+        strict_rate_tier_work_units=100_000,
+    ),
     request_timeout=(3.05, 30.0),
     request_retries=3,
     max_response_bytes=128 * 1024 * 1024,
 )
 ```
 
-The parser has an independent hard ceiling of 200 verses per reference and validates the range size before constructing it. A service may configure stricter values. Public chat and HTTP layers should normally do so.
+The parser has an independent hard ceiling of 200 verses per reference and validates a range before constructing it. Public services should normally configure stricter limits than library defaults.
 
-Legacy open forms such as `John 1:2-` and `John 1:-5` retain their established single-verse meaning. Reversed ranges, zero, malformed punctuation, and ranges above the configured ceiling are rejected.
+Search work units are deterministic and derived from query length, term count, filter count, search mode, and pagination. Requests above `max_work_units` fail before corpus loading. Substring searches enforce a minimum term length. Response bytes are measured before returning data. The response `query.work` object reports work units, the strict-rate-tier decision, deadline, and encoded response size.
+
+## Translation validation order
+
+`search()` and `warm_translation()` validate the translation through the bounded negative TTL/LRU cache before the full-translation cache or its persistent file lock is entered. Repeated requests for a missing code therefore remain bounded and do not create an unbounded lock-file namespace.
+
+## Returned-object ownership
+
+`select()`, `search()`, `warm_translation()`, and `cache_info()` return deep copies. A caller can mutate any returned verse, metadata object, list, or dictionary without corrupting cached source objects or affecting subsequent requests.
 
 ## Typed failures
 
 - `ReferenceValidationError`: malformed or unresolved reference; remains a `ValueError`.
-- `RequestLimitError`: input exceeded a finite work budget; remains a `ValueError`.
+- `RequestLimitError`: input, work, response volume, or deadline exceeded a finite budget; remains a `ValueError`.
 - `TranslationNotFoundError`: missing translation; remains a `FileNotFoundError`.
 - `RepositoryTimeoutError`: connect or read deadline exceeded.
 - `RepositoryResponseTooLarge`: declared or streamed content exceeded the byte cap.
 - `RepositoryError`: other repository access failures.
 
-Applications should map these classes to stable public messages and log unexpected exceptions with a correlation identifier. They should never echo raw exception strings to untrusted users.
-
-## Translation validation
-
-Positive translation data uses the existing bounded book cache. Missing translations use a separate bounded TTL cache so repeated invalid identifiers do not repeatedly reach the repository. Translation codes still require a complete match of the established identifier grammar.
+Applications should map these classes to stable public messages and log unexpected exceptions with a correlation identifier. Never echo raw exception strings to untrusted users.
 
 ## Repository boundary
 
-Both local and HTTP resources are byte-bounded. Remote responses are streamed in 64 KiB chunks; `Content-Length` is checked when present, and the cumulative body length is always enforced. Relative paths reject absolute paths, traversal components, unsafe separators, and unsupported characters.
+Both local and HTTP resources are byte-bounded. Remote responses are streamed in finite chunks; `Content-Length` is checked when present, and cumulative body length is always enforced. Relative paths reject absolute paths, traversal components, unsafe separators, and unsupported characters.
 
-Use HTTPS for remote production repositories. Plain HTTP remains supported for loopback tests and explicitly controlled private deployments for backward compatibility.
+Use HTTPS for remote production repositories. Plain HTTP remains supported only for loopback tests and explicitly controlled private deployments.
 
 ## Application-layer requirements
 
-The library limits protect every caller, but public applications must additionally provide identity-aware rate limiting, bounded concurrency, an outer operation deadline, safe output encoding, generic error messages, and deployment resource limits.
+The Query and Search services must use separate rate tiers. Requests marked `strict_rate_tier=true` require the strict tier. The HTTP process must also enforce an outer deadline slightly above `SearchLimits.deadline_seconds`, bounded concurrency, safe output encoding, generic error messages, and systemd or container memory/task limits.

--- a/src/getbible/__init__.py
+++ b/src/getbible/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
 )
 from .getbible_book_number import GetBibleBookNumber
 from .getbible_reference import BookReference, GetBibleReference
-from .hardened import GetBible, RequestLimits
+from .hardened import GetBible, RequestLimits, SearchLimits
 from .search import SearchBible, SearchCriteria
 
 __all__ = [
@@ -33,6 +33,7 @@ __all__ = [
     "RequestLimits",
     "SearchBible",
     "SearchCriteria",
+    "SearchLimits",
     "SearchValidationError",
     "TranslationNotFoundError",
 ]

--- a/src/getbible/hardened.py
+++ b/src/getbible/hardened.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+import json
 import os
 import threading
 import time
@@ -39,17 +41,53 @@ class RequestLimits:
                 raise TypeError(f"{name} must be an integer.")
             if value < 1:
                 raise ValueError(f"{name} must be positive.")
-        # The parser applies this hard ceiling before materializing a range.
         if self.max_verses_per_reference > 200:
             raise ValueError("max_verses_per_reference cannot exceed the parser ceiling of 200.")
 
 
-class GetBible(_BaseGetBible):
-    """The public Librarian client with bounded parsing and typed failures.
+@dataclass(frozen=True, slots=True)
+class SearchLimits:
+    """Deterministic search work, output, and deadline budgets."""
 
-    Existing retrieval and search response contracts are preserved. Added
-    limits reject abusive input before network or cache work is performed.
-    """
+    max_query_length: int = 500
+    min_substring_length: int = 3
+    max_terms: int = 32
+    max_exclusion_length: int = 128
+    max_filter_values: int = 83
+    max_work_units: int = 500_000
+    max_response_bytes: int = 8 * 1024 * 1024
+    deadline_seconds: float = 10.0
+    strict_rate_tier_work_units: int = 100_000
+
+    def __post_init__(self) -> None:
+        integer_fields = (
+            "max_query_length",
+            "min_substring_length",
+            "max_terms",
+            "max_exclusion_length",
+            "max_filter_values",
+            "max_work_units",
+            "max_response_bytes",
+            "strict_rate_tier_work_units",
+        )
+        for name in integer_fields:
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"{name} must be an integer.")
+            if value < 1:
+                raise ValueError(f"{name} must be positive.")
+        if not isinstance(self.deadline_seconds, int | float) or isinstance(
+            self.deadline_seconds, bool
+        ):
+            raise TypeError("deadline_seconds must be numeric.")
+        if self.deadline_seconds <= 0:
+            raise ValueError("deadline_seconds must be positive.")
+        if self.strict_rate_tier_work_units > self.max_work_units:
+            raise ValueError("strict_rate_tier_work_units cannot exceed max_work_units.")
+
+
+class GetBible(_BaseGetBible):
+    """The public Librarian client with bounded parsing and typed failures."""
 
     def __init__(
         self,
@@ -68,11 +106,13 @@ class GetBible(_BaseGetBible):
         cache_ttl_jitter: float = 0.1,
         *,
         request_limits: RequestLimits | None = None,
+        search_limits: SearchLimits | None = None,
         negative_translation_cache_limit: int = 64,
         negative_translation_ttl: float = 300.0,
         max_response_bytes: int = 128 * 1024 * 1024,
     ) -> None:
         self.request_limits = request_limits or RequestLimits()
+        self.search_limits = search_limits or SearchLimits()
         self._negative_translation_cache_limit = self._bounded_integer(
             "negative_translation_cache_limit",
             negative_translation_cache_limit,
@@ -114,20 +154,19 @@ class GetBible(_BaseGetBible):
         self._negative_translation_evictions = 0
 
     def select(self, reference: str, abbreviation: str | None = "kjv") -> dict[str, Any]:
-        """Return verses after enforcing reference and total-work limits."""
+        """Return caller-owned verses after enforcing request limits."""
         code = self._validated_translation_code(abbreviation)
         self._validated_references(reference, code)
         if not self.valid_translation(code):
             raise TranslationNotFoundError(f"Translation ({code}) not found.")
         try:
-            return super().select(reference, code)
+            return copy.deepcopy(super().select(reference, code))
         except ReferenceValidationError:
             raise
         except ValueError as error:
             raise ReferenceValidationError(str(error)) from error
 
     def valid_reference(self, reference: str, abbreviation: str | None = "kjv") -> bool:
-        """Return whether one bounded reference is structurally resolvable."""
         if not isinstance(reference, str) or len(reference) > self.request_limits.max_input_length:
             return False
         return super().valid_reference(reference, abbreviation)
@@ -138,7 +177,6 @@ class GetBible(_BaseGetBible):
             code = self._validated_translation_code(abbreviation)
         except (TypeError, ValueError):
             return False
-
         if self._negative_translation_cached(code):
             return False
         with self._translation_validation_locks.hold(code):
@@ -158,33 +196,52 @@ class GetBible(_BaseGetBible):
         abbreviation: str | None = "kjv",
         criteria: SearchBible | dict[str, Any] | str | None = None,
     ) -> dict[str, Any]:
-        """Search only after cheap input and criteria checks have passed."""
-        if not isinstance(query, str):
-            raise SearchValidationError("Search query must be a string.")
-        stripped_query = query.strip()
-        if not stripped_query:
-            raise SearchValidationError("Search query cannot be empty.")
-        if len(stripped_query) > 500:
-            raise RequestLimitError("Search query cannot exceed 500 characters.")
-        parsed = SearchBible.from_value(criteria)
-        if parsed.offset > self.request_limits.max_search_offset:
+        """Search after deterministic validation and return caller-owned data."""
+        started = time.monotonic()
+        stripped_query, parsed, work_units = self._validated_search(query, criteria)
+        code = self._validated_translation_code(abbreviation)
+        if not self.valid_translation(code):
+            raise TranslationNotFoundError(f"Translation ({code}) not found.")
+        self._check_search_deadline(started)
+        response = super().search(stripped_query, code, parsed)
+        self._check_search_deadline(started)
+        owned = copy.deepcopy(response)
+        encoded_size = len(
+            json.dumps(owned, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        )
+        if encoded_size > self.search_limits.max_response_bytes:
             raise RequestLimitError(
-                f"Search offset cannot exceed {self.request_limits.max_search_offset}."
+                "Search response exceeds the configured response-volume budget."
             )
-        if len(parsed.books) > self.request_limits.max_search_books:
-            raise RequestLimitError(
-                f"Search cannot select more than {self.request_limits.max_search_books} books."
+        owned["query"]["work"] = {
+            "units": work_units,
+            "strict_rate_tier": work_units > self.search_limits.strict_rate_tier_work_units,
+            "deadline_seconds": float(self.search_limits.deadline_seconds),
+            "response_bytes": encoded_size,
+        }
+        return owned
+
+    def warm_translation(
+        self,
+        abbreviation: str | None = "kjv",
+        *,
+        case_sensitive: bool = False,
+        diacritics: str = "sensitive",
+    ) -> dict[str, Any]:
+        """Warm only translations proven available before cache/lock entry."""
+        code = self._validated_translation_code(abbreviation)
+        if not self.valid_translation(code):
+            raise TranslationNotFoundError(f"Translation ({code}) not found.")
+        return copy.deepcopy(
+            super().warm_translation(
+                code,
+                case_sensitive=case_sensitive,
+                diacritics=diacritics,
             )
-        if len(parsed.exclude) > self.request_limits.max_search_exclusions:
-            raise RequestLimitError(
-                "Search cannot contain more than "
-                f"{self.request_limits.max_search_exclusions} exclusions."
-            )
-        return super().search(stripped_query, abbreviation, parsed)
+        )
 
     def cache_info(self) -> dict[str, Any]:
-        """Return base telemetry plus request and negative-cache limits."""
-        state = super().cache_info()
+        state = copy.deepcopy(super().cache_info())
         now = time.monotonic()
         with self._missing_translations_guard:
             self._purge_expired_missing(now)
@@ -197,6 +254,7 @@ class GetBible(_BaseGetBible):
                 "evictions": self._negative_translation_evictions,
             }
         state["request_limits"] = asdict(self.request_limits)
+        state["search_limits"] = asdict(self.search_limits)
         state["active_translation_validation_locks"] = self._translation_validation_locks.size
         state["repository_max_response_bytes"] = self._repository.max_response_bytes
         return state
@@ -205,6 +263,59 @@ class GetBible(_BaseGetBible):
         with self._missing_translations_guard:
             self._missing_translations.clear()
         super().close()
+
+    def _validated_search(
+        self,
+        query: str,
+        criteria: SearchBible | dict[str, Any] | str | None,
+    ) -> tuple[str, SearchBible, int]:
+        if not isinstance(query, str):
+            raise SearchValidationError("Search query must be a string.")
+        stripped_query = query.strip()
+        if not stripped_query:
+            raise SearchValidationError("Search query cannot be empty.")
+        if len(stripped_query) > self.search_limits.max_query_length:
+            raise RequestLimitError(
+                f"Search query cannot exceed {self.search_limits.max_query_length} characters."
+            )
+        parsed = SearchBible.from_value(criteria)
+        if parsed.offset > self.request_limits.max_search_offset:
+            raise RequestLimitError(
+                f"Search offset cannot exceed {self.request_limits.max_search_offset}."
+            )
+        if len(parsed.books) > min(
+            self.request_limits.max_search_books,
+            self.search_limits.max_filter_values,
+        ):
+            raise RequestLimitError("Search contains too many book filters.")
+        if len(parsed.exclude) > self.request_limits.max_search_exclusions:
+            raise RequestLimitError("Search contains too many exclusion filters.")
+        if any(len(term) > self.search_limits.max_exclusion_length for term in parsed.exclude):
+            raise RequestLimitError("Search exclusion term is too long.")
+        terms = [term for term in stripped_query.split() if term]
+        if len(terms) > self.search_limits.max_terms:
+            raise RequestLimitError("Search contains too many terms.")
+        if parsed.match == "substring" and any(
+            len(term) < self.search_limits.min_substring_length for term in terms
+        ):
+            raise SearchValidationError(
+                "Substring terms must contain at least "
+                f"{self.search_limits.min_substring_length} characters."
+            )
+        filter_factor = max(1, len(parsed.books) + len(parsed.exclude))
+        pagination_factor = parsed.offset + parsed.limit
+        mode_factor = 4 if parsed.match == "substring" else 1
+        phrase_factor = 2 if parsed.words == "phrase" else 1
+        work_units = max(1, len(stripped_query)) * max(1, len(terms))
+        work_units *= filter_factor * mode_factor * phrase_factor
+        work_units += pagination_factor
+        if work_units > self.search_limits.max_work_units:
+            raise RequestLimitError("Search exceeds the configured deterministic work budget.")
+        return stripped_query, parsed, work_units
+
+    def _check_search_deadline(self, started: float) -> None:
+        if time.monotonic() - started > self.search_limits.deadline_seconds:
+            raise RequestLimitError("Search exceeded the configured cooperative deadline.")
 
     def _validated_references(self, reference: str, abbreviation: str) -> None:
         if not isinstance(reference, str):
@@ -216,10 +327,8 @@ class GetBible(_BaseGetBible):
         references = reference.split(";")
         if len(references) > self.request_limits.max_references:
             raise RequestLimitError(
-                "A request cannot contain more than "
-                f"{self.request_limits.max_references} references."
+                f"A request cannot contain more than {self.request_limits.max_references} references."
             )
-
         total_verses = 0
         parser = self._GetBible__get
         for raw_reference in references:
@@ -236,8 +345,7 @@ class GetBible(_BaseGetBible):
             total_verses += selected
             if total_verses > self.request_limits.max_total_verses:
                 raise RequestLimitError(
-                    "A request cannot select more than "
-                    f"{self.request_limits.max_total_verses} verses."
+                    f"A request cannot select more than {self.request_limits.max_total_verses} verses."
                 )
 
     def _negative_translation_cached(self, code: str) -> bool:


### PR DESCRIPTION
## Summary

This PR hardens the public Librarian boundary for the next stable release.

### Changes

- validates missing translations through the bounded negative TTL/LRU cache before Search or warm-up can enter the full-translation cache and persistent lock path;
- adds `SearchLimits` with deterministic work-unit accounting, substring minimums, filter and exclusion bounds, response-volume accounting, strict-rate-tier classification, and operation deadlines;
- deep-copies every public result returned by `select()`, `search()`, `warm_translation()`, and `cache_info()` so callers cannot mutate cached verse or metadata objects;
- exports and documents the production search policy;
- replaces mutable release action tags with immutable commit SHAs;
- gates releases on Python 3.10 through 3.14, freezes checkout to the triggering commit, builds distributions once, adds provenance attestations, and uses PyPI trusted publishing instead of a static API token.

## Validation

The branch is intended to be validated only by the repository's critical `CI` and `Live API Integration` workflows, per project policy. Unrelated workflows are not part of this release gate.

## Operational impact

Public Search deployments should route responses marked `query.work.strict_rate_tier=true` through the strict rate tier and configure an HTTP outer deadline slightly above `SearchLimits.deadline_seconds`.