### PR TITLE
Harden production search, caches, and release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           python -m venv "${RUNNER_TEMP}/getbible-wheel"
           "${RUNNER_TEMP}/getbible-wheel/bin/python" -m pip install dist/*.whl
           cd "${RUNNER_TEMP}"
-          "${RUNNER_TEMP}/getbible-wheel/bin/python" -c "from getbible import GetBible, RequestLimits, SearchBible; assert SearchBible().limit == 100; assert RequestLimits().max_references == 8; GetBible().close()"
+          "${RUNNER_TEMP}/getbible-wheel/bin/python" -c "from getbible import GetBible, RequestLimits, SearchBible, SearchLimits, SourceGeneration; assert SearchBible().limit == 100; assert RequestLimits().max_references == 8; assert SearchLimits().max_work_units == 50000000; assert SourceGeneration('test', 0, 'initial', 0).cache_namespace == 'test:g0'; GetBible().close()"
 
       - name: Upload distributions
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,109 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  prepare:
+    name: Freeze release source
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: pypi
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      tag: ${{ steps.release.outputs.tag }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && 'master' || github.ref }}
 
+      - name: Freeze and verify release commit
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSHED_TAG: ${{ github.ref_name }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin master
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="v${REQUESTED_VERSION}"
+            RELEASE_COMMIT="$(git rev-parse origin/master)"
+          else
+            RELEASE_TAG="${PUSHED_TAG}"
+            RELEASE_COMMIT="$(git rev-parse HEAD)"
+            git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/master || {
+              echo "Release tag must point to a commit contained in master." >&2
+              exit 1
+            }
+          fi
+          git checkout --detach "${RELEASE_COMMIT}"
+          python scripts/check_release_version.py "${RELEASE_TAG}"
+          echo "commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+
+  test:
+    name: Python ${{ matrix.python-version }} release gate
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout frozen source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Compile and test
+        run: |
+          python -m compileall -q src tests
+          python -m unittest discover -s tests -v
+
+  build:
+    name: Build and attest once
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout frozen source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -36,62 +121,113 @@ jobs:
             pyproject.toml
             requirements-dev.txt
 
-      - name: Install development tools
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
-      - name: Resolve and verify release tag
-        id: release-tag
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PUSHED_TAG: ${{ github.ref_name }}
-          REQUESTED_VERSION: ${{ inputs.version }}
+      - name: Build and verify distributions
         run: |
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="v${REQUESTED_VERSION}"
-          else
-            RELEASE_TAG="${PUSHED_TAG}"
-          fi
-          python scripts/check_release_version.py "${RELEASE_TAG}"
-          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          python -m build
+          python -m twine check dist/*
 
-      - name: Run tests
-        run: python -m unittest discover -s tests -v
-
-      - name: Build distributions
-        run: python -m build
-
-      - name: Verify distributions
-        run: python -m twine check dist/*
-
-      - name: Create and push release tag
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+      - name: Test built wheel in isolation
         run: |
+          python -m venv "${RUNNER_TEMP}/getbible-wheel"
+          "${RUNNER_TEMP}/getbible-wheel/bin/python" -m pip install dist/*.whl
+          cd "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/getbible-wheel/bin/python" -c "from getbible import GetBible, SearchLimits; assert SearchLimits().max_work_units == 50000000; GetBible().close()"
+
+      - name: Attest distributions
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: dist/*
+
+      - name: Upload frozen distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: getbible-release-${{ needs.prepare.outputs.commit }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14
+
+  tag:
+    name: Create immutable tag
+    needs: [prepare, test, build]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout frozen source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.commit }}
+
+      - name: Create release tag without moving an existing tag
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_COMMIT: ${{ needs.prepare.outputs.commit }}
+        run: |
+          set -euo pipefail
           git fetch --tags origin
-          CURRENT_COMMIT="$(git rev-parse HEAD)"
           if git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}"; then
             TAG_COMMIT="$(git rev-list -n 1 "${RELEASE_TAG}")"
-            if [ "${TAG_COMMIT}" != "${CURRENT_COMMIT}" ]; then
-              echo "Tag ${RELEASE_TAG} already points to ${TAG_COMMIT}, not ${CURRENT_COMMIT}." >&2
+            if [ "${TAG_COMMIT}" != "${RELEASE_COMMIT}" ]; then
+              echo "Tag ${RELEASE_TAG} already points to ${TAG_COMMIT}." >&2
               exit 1
             fi
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
-            git push origin "${RELEASE_TAG}"
+            git tag -a "${RELEASE_TAG}" "${RELEASE_COMMIT}" -m "Release ${RELEASE_TAG}"
+            git push origin "refs/tags/${RELEASE_TAG}"
           fi
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  publish:
+    name: Publish trusted artifact
+    needs: [prepare, test, build, tag]
+    if: always() && needs.prepare.result == 'success' && needs.test.result == 'success' && needs.build.result == 'success' && (needs.tag.result == 'success' || needs.tag.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/getbible/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download frozen distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: getbible-release-${{ needs.prepare.outputs.commit }}
+          path: dist
+
+      - name: Publish to PyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  github-release:
+    name: Create GitHub release
+    needs: [prepare, build, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download published distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: getbible-release-${{ needs.prepare.outputs.commit }}
+          path: dist
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: gh release create "${RELEASE_TAG}" dist/* --generate-notes --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+.venv-*/
 env/
 venv/
 ENV/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable project changes are documented here.
 - Typed reference, work-budget, translation, timeout, and oversized-response exceptions.
 - Request-level reference, verse, search-pagination, and response-body budgets.
 - Bounded negative translation caching and parser fuzz/regression coverage.
+- Deterministic `SearchLimits`, response-volume accounting, substring minimums, cooperative deadlines, and pre-execution `SearchBible.expensive` classification.
+- Atomic source-generation manifests, reader/transition barriers, stable external cache namespaces, failure-serialized purge callbacks, and worker cache invalidation.
+- Maintained Query and Search systemd resource-limit drop-ins.
 
 ### Changed
 
@@ -34,6 +37,8 @@ All notable project changes are documented here.
 - Replaced permanently retained keyed locks with reference-counted per-resource coordination.
 - Repository downloads now stream into a finite byte budget and validate path, timeout, retry, and backoff configuration.
 - CI now compiles every source file and runs static security and dependency-advisory scans without removing any existing test or package checks.
+- Full translations now use validation-versioned, content-addressed immutable payloads with atomic metadata commits and independent books-index validation.
+- Release publication now freezes one `master` commit, gates Python 3.10–3.14, builds once, attests the distributions, and uses PyPI trusted publishing.
 
 ### Fixed
 
@@ -44,6 +49,9 @@ All notable project changes are documented here.
 - Verse ranges are bounded before `range()` is materialized, closing a remote memory-exhaustion path.
 - Reversed and malformed ranges fail closed instead of returning a different verse.
 - Cached `BookReference.verses` lists can no longer be mutated by callers.
+- Search and warm-up now reject missing translations through the bounded negative cache before entering abbreviation-specific translation payload or lock paths.
+- Full-translation and chapter SHA enforcement, complete nested validation, and last-known-good preservation now cover malformed upstream refreshes.
+- Returned Query and Search verses and metadata are deep copies independent of every internal cache.
 
 ## [1.1.2] - 2023-12-11
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include SECURITY.md
 include requirements.txt
 include requirements-dev.txt
 recursive-include benchmarks *.py
+recursive-include deploy *.conf
 recursive-include docs *.md
 recursive-include examples *.py
 recursive-include scripts *.py

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ print(encoded)
 ```python
 import json
 
-from getbible import GetBible, SearchBible
+from getbible import GetBible, SearchBible, SearchLimits
 
 
-bible = GetBible()
+bible = GetBible(
+    search_limits=SearchLimits(
+        max_work_units=50_000_000,
+        max_response_bytes=4 * 1024 * 1024,
+        deadline_seconds=5.0,
+    )
+)
 criteria = SearchBible(
     words="all",
     match="whole_word",
@@ -66,7 +72,7 @@ print(json.dumps(response, ensure_ascii=False, indent=2))
 
 Search responses contain three top-level objects:
 
-- `query`: normalized criteria, translation metadata, exact total, pagination, SHA, and cache state.
+- `query`: normalized criteria, translation metadata, exact total, pagination, SHA, cache state, and deterministic search cost.
 - `results`: the same grouped scripture object format returned by `select()`.
 - `matches`: ordered per-verse match metadata, including score, occurrences, and matched terms.
 
@@ -120,10 +126,15 @@ bible = GetBible(
     cache_dir="/var/cache/getbible",
     cache_ttl=timedelta(days=7),
     strict_freshness=False,
+    require_checksums=True,
 )
 ```
 
-Cache replacements are checksum-verified, process-locked, and atomic. A last-known-good translation remains available during temporary repository failures unless `strict_freshness=True`.
+Remote production checksums are required. Full corpora and their independent
+books indexes are completely validated before immutable, content-addressed
+payloads are atomically committed. A last-known-good translation remains
+available during temporary repository or newly published integrity failures
+unless `strict_freshness=True`.
 
 Production caches are bounded by default. A service can warm its expected
 translation without issuing an artificial query and can expose cache counters to
@@ -138,6 +149,10 @@ bible = GetBible(
 bible.warm_translation("kjv")
 cache_state = bible.cache_info()
 ```
+
+Atomically updated local mirrors can coordinate application response caches and
+worker-local invalidation with `source_operation()` and
+`transition_source()`. See [Cache validation and retention](docs/CACHING.md).
 
 Call `bible.close()` during worker shutdown, or use `GetBible` as a context
 manager in short-lived scripts.

--- a/deploy/systemd/getbible-query.service.d/limits.conf
+++ b/deploy/systemd/getbible-query.service.d/limits.conf
@@ -1,0 +1,13 @@
+[Service]
+MemoryAccounting=yes
+MemoryHigh=384M
+MemoryMax=512M
+MemorySwapMax=0
+CPUAccounting=yes
+CPUQuota=200%
+TasksAccounting=yes
+TasksMax=64
+LimitNOFILE=4096
+OOMPolicy=stop
+TimeoutStartSec=90
+TimeoutStopSec=30

--- a/deploy/systemd/getbible-search.service.d/limits.conf
+++ b/deploy/systemd/getbible-search.service.d/limits.conf
@@ -1,0 +1,13 @@
+[Service]
+MemoryAccounting=yes
+MemoryHigh=2G
+MemoryMax=3G
+MemorySwapMax=0
+CPUAccounting=yes
+CPUQuota=400%
+TasksAccounting=yes
+TasksMax=128
+LimitNOFILE=8192
+OOMPolicy=stop
+TimeoutStartSec=180
+TimeoutStopSec=45

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -82,11 +82,20 @@ URL-decode values exactly once and pass only supplied, validated filters:
 
 ```python
 criteria = SearchBible.from_value(validated_filter_values)
-response = bible.search(query, translation, criteria)
+rate_tier = "strict" if criteria.expensive else "normal"
+with limiter.reserve(caller_identity, tier=rate_tier):
+    response = bible.search(query, translation, criteria)
 ```
 
 Do not pass raw query values through Python truthiness (`bool("false")` is
 `True`), silently ignore unknown filters, or expose regular expressions.
+
+The strict tier must have a lower sustained rate and burst than the normal
+tier. Apply it before calling `search()`; do not discover that a request is
+expensive only after loading a translation. Independently cap concurrent
+Search requests and place an application deadline outside Librarian's
+cooperative deadline. Recommended starting values and timeout ordering are in
+[Multi-worker API operations](OPERATIONS.md).
 
 Return `bible.search()` directly as JSON. Its `results` object retains the same
 chapter-keyed Scripture structure as `select()`; `query` and `matches` are the
@@ -127,3 +136,12 @@ The search response `query.sha` identifies the exact translation payload and
 text by default; application and reverse-proxy access logs should retain
 request identifiers, lengths, counts, status, and timing without recording the
 query string.
+
+For a shared Redis, Memcached, filesystem, or proxy response cache, wrap the
+entire lookup/call/write transaction in `source_operation()` and prefix the key
+with `source.cache_namespace`. Activate a completed immutable mirror using
+`transition_source(revision, purge_callback)`. The transition excludes readers,
+serializes the external purge, commits the generation only after purge
+succeeds, and causes every worker to invalidate process-local state before it
+serves the new generation. Query and Search still require separate response
+cache instances even when they use the same source revision.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,7 @@
 | `getbible.py` | Public facade, grouped scripture output, and cache coordination |
 | `repository_client.py` | Remote/local resource access, retries, timeouts, and fork-safe connection pooling |
 | `translation_cache.py` | SHA validation, disk persistence, atomic replacement, and stale fallback |
+| `source_generation.py` | Atomic mirror generations, cross-worker barriers, response-cache namespaces, and invalidation |
 | `search.py` | Criteria validation, corpus construction, postings indexes, matching, scoring, and pagination |
 | `getbible_reference.py` | Reference parsing and translation-aware LRU caching |
 | `getbible_book_number.py` | Translation alias selection and fallback |
@@ -81,3 +82,10 @@ separates them. Query maps `GET /v2/{translation}/{reference}` to `select()`;
 Search maps `GET /v2/{translation}?q=...` to `search()`. They run with separate
 process and cache budgets. The earlier combined `/v2/search/{translation}`
 shape is not part of the supported deployment contract.
+
+The source-generation layer is independent of per-translation freshness. A
+deployment activates a completed immutable mirror revision with
+`transition_source()`. Requests and external response-cache transactions use
+`source_operation()` so a purge and generation change cannot race a read. The
+stable repository namespace plus monotonic generation prevents old response
+keys from becoming valid again after a transition.

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -6,7 +6,11 @@ Librarian uses separate strategies for lightweight reference retrieval and full-
 
 `select()` requests only the required chapter. The parsed chapter is retained in memory with direct verse lookup by verse number.
 
-After the configured interval, Librarian checks the chapter SHA endpoint. If the SHA is unchanged, only the freshness timestamp changes. If it changed or is unavailable, Librarian retrieves the chapter JSON again.
+Before retaining a chapter, Librarian retrieves and validates its SHA endpoint,
+downloads the JSON, validates the exact checksum, and validates every required
+chapter and verse field. After the configured interval, an unchanged SHA only
+updates freshness. Remote production repositories must publish the checksum;
+checksum-free local fixtures remain supported.
 
 No cache-maintenance background thread is created.
 
@@ -18,19 +22,22 @@ The first search for a translation follows this sequence:
 2. Acquire a cross-process file lock for the translation.
 3. Read and validate an existing disk entry when present.
 4. Retrieve `/v2/{translation}.sha`.
-5. Download `/v2/{translation}.json` only when needed.
-6. Calculate SHA-1 over the received bytes.
-7. Compare it with the published SHA.
-8. Validate the translation and books structure.
-9. Atomically replace the disk JSON and metadata.
-10. Build the immutable in-memory corpus and default postings index.
+5. Retrieve and independently validate `/v2/{translation}/books.json`.
+6. Download `/v2/{translation}.json` only when needed.
+7. Calculate SHA-1 over the received bytes and compare it with the published SHA.
+8. Validate every book, chapter, verse, numeric range, unique identifier, text
+   ceiling, and the exact books-index correspondence.
+9. Write the validated JSON as an immutable `objects/{sha}.json` payload.
+10. Atomically commit versioned metadata that points at that content-addressed
+    payload.
+11. Build the immutable in-memory corpus and default postings index.
 
 When the source SHA is unchanged, Librarian updates only freshness state and
 retains the existing corpus and every already-built index. It does not reread
 and decode the full disk JSON or rebuild postings merely because the freshness
 interval elapsed.
 
-The published GetBible `.sha` value is the raw SHA-1 of the corresponding JSON bytes.
+The published GetBible `.sha` value is the raw SHA-1 of the corresponding JSON bytes. HTTP/HTTPS repositories require it by default. Set `require_checksums=False` only for a controlled compatibility source; set `require_checksums=True` to enforce the production rule for a local mirror.
 
 ## Refresh interval
 
@@ -71,7 +78,12 @@ The cache namespace includes a hash of the repository URL or path and its API ve
 
 ## Cross-process safety
 
-`filelock` coordinates initial downloads and replacements. JSON and metadata are written to temporary files, flushed, and atomically moved into place. Other workers continue reading a complete previous file or the complete replacement.
+`filelock` coordinates initial downloads and commits. Immutable payloads and
+metadata are written to temporary files, flushed, atomically moved into place,
+and followed by a directory `fsync`. Metadata is the commit point. A process
+crash can leave an unreferenced immutable object, but cannot make a partially
+validated object current. Metadata includes a validation-version marker so a
+future validator upgrade forces complete revalidation.
 
 Each process maintains its own in-memory corpus and indexes. The shared disk cache prevents every worker from downloading the full translation independently.
 
@@ -99,11 +111,46 @@ bible = GetBible(strict_freshness=True)
 
 In strict mode, repository failures propagate instead of serving the older translation.
 
-Checksum mismatches never replace the last-known-good translation.
+Checksum, nested validation, and books-index mismatches never replace the
+last-known-good translation. Unless strict freshness is enabled, a validated
+last-known-good corpus remains available and is marked stale when a newly
+published upstream payload fails integrity validation.
+
+## Source generations
+
+The repository URL/path plus API version produces a stable namespace. A
+versioned `source-generation.json` manifest records the active immutable mirror
+revision. `transition_source()` takes the cross-process writer barrier, runs the
+configured response-cache purge callback exactly once, commits the manifest,
+and invalidates worker-local books, chapters, full translations, indexes, and
+negative translation entries. A purge failure leaves the old generation
+committed.
+
+Use `source_operation()` to keep the generation stable while an application
+performs an external response-cache lookup, Librarian call, and response-cache
+write:
+
+```python
+with bible.source_operation() as source:
+    key = f"{source.cache_namespace}:{canonical_request_key}"
+    response = response_cache.get(key)
+    if response is None:
+        response = bible.search(query, translation, criteria)
+        response_cache.set(key, response)
+```
+
+The reader/transition barrier spans threads and Linux worker processes. A
+worker that observes a generation committed by another worker invalidates its
+process-local caches before serving that generation. Translation metadata also
+records the source generation; an older disk snapshot becomes immediately due
+for source revalidation, even when its ordinary cache TTL has not elapsed.
 
 ## Rotation
 
-Each repository, API version, and translation combination keeps one current JSON payload and one metadata file. Updates replace the existing entry rather than accumulating historical full translations. Lock files contain no scripture data.
+Each translation metadata file points to one current content-addressed payload.
+Older unreferenced objects may be removed during controlled cache maintenance
+after all workers have observed the new generation. Lock and barrier files
+contain no scripture data.
 
 Use `GetBible.cache_info()` to observe current sizes, configured limits,
 evictions, source checks, downloads, stale fallbacks, loaded SHA values, and

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -5,7 +5,7 @@
 ## Default request limits
 
 ```python
-from getbible import GetBible, RequestLimits
+from getbible import GetBible, RequestLimits, SearchLimits
 
 bible = GetBible(
     request_limits=RequestLimits(
@@ -13,9 +13,19 @@ bible = GetBible(
         max_references=8,
         max_verses_per_reference=200,
         max_total_verses=200,
-        max_search_offset=10_000,
-        max_search_books=83,
-        max_search_exclusions=32,
+    ),
+    search_limits=SearchLimits(
+        max_work_units=50_000_000,
+        max_response_bytes=4 * 1024 * 1024,
+        max_query_length=500,
+        max_query_terms=64,
+        min_substring_length=3,
+        max_books=83,
+        max_exclusions=32,
+        max_exclusion_terms=64,
+        max_offset=10_000,
+        max_limit=1_000,
+        deadline_seconds=5.0,
     ),
     request_timeout=(3.05, 30.0),
     request_retries=3,
@@ -25,12 +35,27 @@ bible = GetBible(
 
 The parser has an independent hard ceiling of 200 verses per reference and validates the range size before constructing it. A service may configure stricter values. Public chat and HTTP layers should normally do so.
 
+Search work is estimated deterministically from the corpus index, requested
+criteria, filter breadth, sorting mode, and response page before matching is
+allowed to continue. Execution performs cooperative deadline checks while
+building an index, scanning postings, testing phrases, and evaluating
+proximity. The response is serialized into the configured byte budget before
+it is returned.
+
+Substring terms must contain at least three characters by default. This stops
+one-character vocabulary scans before the translation corpus is loaded.
+`SearchBible.expensive` classifies substring, phrase, any-word, proximity,
+relevance, exclusion, insensitive-diacritic, deep-offset, and large-page
+criteria before execution so the HTTP layer can apply its strict rate tier.
+
 Legacy open forms such as `John 1:2-` and `John 1:-5` retain their established single-verse meaning. Reversed ranges, zero, malformed punctuation, and ranges above the configured ceiling are rejected.
 
 ## Typed failures
 
 - `ReferenceValidationError`: malformed or unresolved reference; remains a `ValueError`.
 - `RequestLimitError`: input exceeded a finite work budget; remains a `ValueError`.
+- `SearchLimitError`: deterministic work, filter, pagination, or response budget exceeded; it is both a `SearchValidationError` and `RequestLimitError`.
+- `SearchDeadlineExceeded`: cooperative search deadline elapsed; it is also a `TimeoutError`.
 - `TranslationNotFoundError`: missing translation; remains a `FileNotFoundError`.
 - `RepositoryTimeoutError`: connect or read deadline exceeded.
 - `RepositoryResponseTooLarge`: declared or streamed content exceeded the byte cap.
@@ -40,7 +65,14 @@ Applications should map these classes to stable public messages and log unexpect
 
 ## Translation validation
 
-Positive translation data uses the existing bounded book cache. Missing translations use a separate bounded TTL cache so repeated invalid identifiers do not repeatedly reach the repository. Translation codes still require a complete match of the established identifier grammar.
+Positive translation data uses the existing bounded book cache. Missing translations use a separate bounded TTL/LRU cache so repeated invalid identifiers do not repeatedly reach the repository. Search and warm-up perform this check before an abbreviation-specific translation payload path or lock can be created. Translation codes still require a complete match of the established identifier grammar.
+
+Remote repositories require published full-translation and chapter SHA-1
+checksums by default. Local repositories permit checksum-free fixtures unless
+`require_checksums=True` is selected. Complete corpus validation enforces
+bounded book/chapter/verse counts, numeric ranges, unique identifiers, required
+text fields, chapter consistency, and equality with the independent
+`books.json` index before a payload can become last-known-good data.
 
 ## Repository boundary
 
@@ -50,4 +82,4 @@ Use HTTPS for remote production repositories. Plain HTTP remains supported for l
 
 ## Application-layer requirements
 
-The library limits protect every caller, but public applications must additionally provide identity-aware rate limiting, bounded concurrency, an outer operation deadline, safe output encoding, generic error messages, and deployment resource limits.
+The library limits protect every caller, but public applications must additionally provide identity-aware rate limiting, bounded concurrency, an outer operation deadline shorter than the proxy timeout, safe output encoding, generic error messages, and deployment resource limits. See [Multi-worker API operations](OPERATIONS.md) for the normal/strict tiers and maintained systemd drop-ins.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -9,10 +9,14 @@ independent services so search CPU and memory cannot consume Query capacity.
 Create one client during application initialization or once per worker. Do not construct a new client for every HTTP request.
 
 ```python
-from getbible import GetBible
+from getbible import GetBible, SearchLimits
 
 
-bible = GetBible(cache_dir="/var/cache/getbible")
+bible = GetBible(
+    cache_dir="/var/cache/getbible",
+    require_checksums=True,
+    search_limits=SearchLimits(deadline_seconds=5.0),
+)
 
 
 def execute_scripture_query(reference: str, translation: str) -> dict:
@@ -94,6 +98,30 @@ same local API mirror but should never share a writable cache directory.
 
 The library restricts a page to 1,000 matches. The API layer may impose a smaller public maximum. Exact totals are reported independently of the returned page.
 
+## Search tiers and outer deadlines
+
+Parse `SearchBible` before entering a rate-limiter reservation. Its
+`expensive` property is deliberately corpus-independent:
+
+```python
+criteria = SearchBible.from_value(filters)
+tier = "strict" if criteria.expensive else "normal"
+with limiter.reserve(identity, tier=tier):
+    response = bible.search(query, translation, criteria)
+```
+
+Use independent counters for the two tiers. A production starting point is 60
+normal searches per minute with a burst of 10, and 12 strict searches per
+minute with a burst of 3, per authenticated identity and per source IP. Tune
+from measured capacity; never combine the strict and normal burst pools.
+
+The default cooperative Librarian deadline is 5 seconds. The application
+server should use a 7-second request deadline and the reverse proxy a 10-second
+upstream deadline, leaving time to translate a typed failure into a clean HTTP
+response. Repository connect/read timeouts govern source refresh separately.
+Do not rely on a proxy timeout to stop Python work: it disconnects the caller
+but does not itself cancel matching.
+
 ## Timeouts and retries
 
 Defaults:
@@ -104,6 +132,29 @@ Defaults:
 - Retry statuses: 429, 500, 502, 503, and 504.
 
 Override these through `GetBible()` when the hosting environment requires different limits.
+
+## systemd cgroup limits
+
+Maintained baseline drop-ins are provided for independent Query and Search
+units:
+
+```bash
+sudo install -D -m 0644 \
+  deploy/systemd/getbible-query.service.d/limits.conf \
+  /etc/systemd/system/getbible-query.service.d/limits.conf
+sudo install -D -m 0644 \
+  deploy/systemd/getbible-search.service.d/limits.conf \
+  /etc/systemd/system/getbible-search.service.d/limits.conf
+sudo systemctl daemon-reload
+sudo systemctl restart getbible-query.service getbible-search.service
+sudo systemctl show getbible-query.service getbible-search.service \
+  -p MemoryHigh -p MemoryMax -p MemorySwapMax -p CPUQuotaPerSecUSec -p TasksMax
+```
+
+The Query baseline is 512 MiB/200% CPU/64 tasks. Search is isolated at 3
+GiB/400% CPU/128 tasks. Both disable swap for the unit and stop on an OOM event.
+Treat these as tested starting limits: lower corpus counts before raising
+`MemoryMax`, and validate the chosen values under a full-translation load test.
 
 ## Monitoring
 

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -23,10 +23,17 @@ CI runs deterministic tests on Python 3.10 through 3.14, then installs and impor
 - malformed or reversed ranges never resolve to verse 1 or another unintended verse;
 - per-reference and aggregate verse budgets are both enforced;
 - repeated missing translations use bounded negative caching;
+- missing Search and warm-up translations are rejected before abbreviation-specific translation payload paths and locks;
 - oversized local and remote repository bodies are rejected;
 - repository traversal is rejected;
 - blank and excessive search inputs fail before translation loading;
-- cache entries cannot be corrupted through a returned mutable verse list;
+- substring, deterministic work, output-volume, filter, and cooperative deadline budgets fail closed;
+- full corpora and independent books indexes are completely validated before a versioned content-addressed payload is committed;
+- production full-translation and chapter checksums are required and compared;
+- invalid upstream refreshes preserve the last-known-good corpus;
+- Query and Search return deep copies that cannot corrupt cached verses or metadata;
+- source-generation purge failures do not commit and successful transitions invalidate other workers;
+- the release artifact is built once, attested, trusted-published, and reused for the GitHub release;
 - all historical parser, Unicode, search, cache, local/HTTP parity, and packaging tests still pass.
 
 ## Operational gate

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,7 +51,12 @@ The artifact can be downloaded and installed in a clean environment before relea
 5. Merge the exact release state into `master`.
 6. Open the GitHub Actions **Release** workflow, choose **Run workflow**, and enter the version without the leading `v`.
 
-The workflow always checks out `master`, requires the entered version to match `pyproject.toml`, and creates the corresponding `v<version>` tag only after tests and package validation pass. It refuses to move an existing tag. Directly pushing a correctly formatted tag remains supported for maintainers who need that route.
+The workflow freezes the current `master` SHA in its preparation job, requires
+the entered version to match `pyproject.toml`, and passes that exact SHA to
+every later job. It creates the corresponding `v<version>` tag only after all
+tests and package validation pass, and refuses to move an existing tag.
+Directly pushing a correctly formatted tag remains supported when the tagged
+commit belongs to `master`.
 
 ## Automated release
 
@@ -59,10 +64,19 @@ The manually triggered release workflow:
 
 1. Checks out the exact `master` release commit.
 2. Verifies the entered version against the package version.
-3. Installs the project development tools and runs deterministic tests.
-4. Builds source and wheel distributions and runs `twine check`.
-5. Creates and pushes the immutable `v<version>` tag.
-6. Publishes with the `PYPI_API_TOKEN` environment secret.
-7. Creates a GitHub release with generated commit notes and both distributions.
+3. Runs the deterministic gate against the frozen commit on Python 3.10–3.14.
+4. Builds source and wheel distributions once, runs `twine check`, installs the
+   wheel in isolation, and creates GitHub build-provenance attestations.
+5. Uploads those exact distributions as the immutable workflow artifact.
+6. Creates and pushes the immutable `v<version>` tag.
+7. Downloads the same artifact and publishes it through PyPI trusted publishing.
+8. Downloads the same artifact again for the GitHub release; no rebuild occurs.
 
-Configure the `pypi` GitHub environment and its `PYPI_API_TOKEN` secret before running a release.
+Configure the `pypi` GitHub environment and add this repository as a trusted
+publisher for the `getbible` project in PyPI. No long-lived PyPI API token is
+read by the workflow. Keep environment protection rules enabled so the OIDC
+publication job receives approval independently of branch write access.
+
+Every third-party Action is pinned to a complete immutable commit SHA. Update
+the SHA and its adjacent version comment together after reviewing the upstream
+release diff.

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -24,6 +24,11 @@ encoded = bible.search_json("faith hope", "kjv")
 
 `SearchBible` is the canonical public class name. `SearchCriteria` remains available as a compatibility alias for integrations that adopted the earlier development name.
 
+`SearchBible.expensive` is available immediately after parsing, before a
+translation is loaded. Public endpoints should use it to select the strict
+rate tier. It is true for substring, phrase, any-word, proximity, relevance,
+exclusion, insensitive-diacritic, deep-offset, and large-page criteria.
+
 | Field | Values | Default |
 |---|---|---|
 | `words` | `all`, `any`, `phrase` | `all` |
@@ -139,6 +144,10 @@ query
   returned
   has_more
   cache
+  cost
+    work_units
+    deadline_seconds
+    expensive
 results
   <translation>_<book>_<chapter>
     translation metadata
@@ -160,6 +169,13 @@ matches
 `matches` preserves global search order. This is especially important for relevance sorting because `results` groups verses by chapter.
 
 The `sha` field identifies the exact full-translation payload used for the search, enabling downstream response-cache invalidation.
+
+`cost.work_units` is the deterministic estimate enforced by
+`SearchLimits.max_work_units`; it is suitable for aggregate metrics but is not
+wall-clock time. `deadline_seconds` reports the cooperative library deadline,
+and `expensive` mirrors the pre-execution rate-tier classification. The exact
+serialized response size is enforced internally but is not echoed because a
+size field would itself change the serialized size.
 
 ## Legacy criteria notation
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,7 +5,7 @@
 ```python
 from datetime import timedelta
 
-from getbible import GetBible
+from getbible import GetBible, SearchLimits
 
 
 bible = GetBible(
@@ -22,10 +22,15 @@ bible = GetBible(
     search_corpus_limit=4,
     translation_cache_limit=4,
     cache_ttl_jitter=0.1,
+    require_checksums=True,
+    search_limits=SearchLimits(),
 )
 ```
 
-All constructor arguments are optional. The defaults use GetBible API v2 and the operating system's user cache directory.
+All constructor arguments are optional. The defaults use GetBible API v2 and
+the operating system's user cache directory. Checksums are required
+automatically for HTTP/HTTPS repositories and optional for local repositories;
+pass `require_checksums=True` for a production local mirror.
 
 For services, construct a long-lived client rather than one client per request. The client is safe for concurrent threads, and each process receives fork-safe HTTP sessions.
 
@@ -144,7 +149,8 @@ Expected paths include:
 /srv/getbible-data/v2/kjv.sha
 ```
 
-The `.sha` resource is optional for local fixtures but recommended for production repositories.
+The `.sha` resource is optional for local fixtures and required for remote
+repositories. Production local mirrors should opt into the same enforcement.
 
 ## Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "requests>=2.31,<3",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",

--- a/src/getbible/__init__.py
+++ b/src/getbible/__init__.py
@@ -8,13 +8,16 @@ from .exceptions import (
     RepositoryResponseTooLarge,
     RepositoryTimeoutError,
     RequestLimitError,
+    SearchDeadlineExceeded,
+    SearchLimitError,
     SearchValidationError,
     TranslationNotFoundError,
 )
 from .getbible_book_number import GetBibleBookNumber
 from .getbible_reference import BookReference, GetBibleReference
 from .hardened import GetBible, RequestLimits
-from .search import SearchBible, SearchCriteria
+from .search import SearchBible, SearchCriteria, SearchLimits
+from .source_generation import SourceGeneration
 
 __all__ = [
     "BookReference",
@@ -33,6 +36,10 @@ __all__ = [
     "RequestLimits",
     "SearchBible",
     "SearchCriteria",
+    "SearchDeadlineExceeded",
+    "SearchLimitError",
+    "SearchLimits",
     "SearchValidationError",
+    "SourceGeneration",
     "TranslationNotFoundError",
 ]

--- a/src/getbible/exceptions.py
+++ b/src/getbible/exceptions.py
@@ -43,3 +43,11 @@ class CacheIntegrityError(GetBibleError):
 
 class SearchValidationError(ValueError, GetBibleError):
     """Raised when a search query or its criteria are invalid."""
+
+
+class SearchLimitError(SearchValidationError, RequestLimitError):
+    """Raised before a search can exceed its deterministic resource budget."""
+
+
+class SearchDeadlineExceeded(SearchLimitError, TimeoutError):
+    """Raised when cooperative search execution reaches its deadline."""

--- a/src/getbible/getbible.py
+++ b/src/getbible/getbible.py
@@ -9,15 +9,30 @@ import re
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 from ._keyed_locks import KeyedLockPool
-from .exceptions import CacheIntegrityError, RepositoryResourceNotFound
+from .exceptions import (
+    CacheIntegrityError,
+    RepositoryResourceNotFound,
+    RepositoryResponseError,
+    SearchLimitError,
+)
 from .getbible_reference import BookReference, GetBibleReference
 from .repository_client import RepositoryClient
-from .search import SearchBible, SearchEngine, SearchHit, TranslationCorpus
+from .search import (
+    SearchBible,
+    SearchEngine,
+    SearchHit,
+    SearchLimits,
+    TranslationCorpus,
+)
+from .source_generation import PurgeCallback, SourceCoordinator, SourceGeneration
 from .translation_cache import TranslationCache
 
 
@@ -74,6 +89,9 @@ class GetBible:
         search_corpus_limit: int | None = 4,
         translation_cache_limit: int | None = 4,
         cache_ttl_jitter: float = 0.1,
+        require_checksums: bool | None = None,
+        source_purge_callback: PurgeCallback | None = None,
+        search_limits: SearchLimits | None = None,
     ) -> None:
         reference_cache_limit = self._validated_cache_limit(
             "reference_cache_limit", reference_cache_limit
@@ -97,6 +115,14 @@ class GetBible:
             timeout=request_timeout,
             retries=request_retries,
         )
+        if require_checksums is not None and not isinstance(require_checksums, bool):
+            raise TypeError("require_checksums must be a boolean or null.")
+        self._require_checksums = (
+            self._repository.is_url if require_checksums is None else require_checksums
+        )
+        if search_limits is not None and not isinstance(search_limits, SearchLimits):
+            raise TypeError("search_limits must be a SearchLimits object or null.")
+        self.search_limits = search_limits or SearchLimits()
         self._cache_ttl_seconds = max(0.0, cache_ttl.total_seconds())
         self.__books_cache: OrderedDict[str, _CacheEntry] = OrderedDict()
         self.__chapters_cache: OrderedDict[str, _CacheEntry] = OrderedDict()
@@ -114,24 +140,35 @@ class GetBible:
             strict_freshness=strict_freshness,
             memory_limit=translation_cache_limit,
             refresh_jitter=cache_ttl_jitter,
+            require_checksums=self._require_checksums,
         )
         self._search_corpora: OrderedDict[str, TranslationCorpus] = OrderedDict()
+        self._source_coordinator = SourceCoordinator(
+            cache_root=self._translation_cache.cache_dir,
+            source=self._repository.repo_path,
+            version=self._repository.version,
+            invalidate_callback=self._invalidate_worker_caches,
+            purge_callback=source_purge_callback,
+        )
+        initial_generation = self._source_coordinator.info()["generation"]
+        self._translation_cache.set_source_generation(int(initial_generation))
 
     def select(self, reference: str, abbreviation: str | None = 'kjv') -> dict[str, Any]:
         """Return Bible verses using the established grouped result contract."""
-        abbreviation = self._validated_translation_code(abbreviation)
-        self.__check_translation(abbreviation)
-        result: dict[str, Any] = {}
-        for raw_reference in reference.split(';'):
-            ref = raw_reference.strip()
-            if not ref:
-                raise ValueError("Invalid empty reference.")
-            try:
-                book_reference = self.__get.ref(ref, abbreviation)
-            except ValueError as error:
-                raise ValueError(f"Invalid reference '{ref}'.") from error
-            self.__set_verse(abbreviation, book_reference, result)
-        return result
+        with self.source_operation():
+            abbreviation = self._validated_translation_code(abbreviation)
+            self.__check_translation(abbreviation)
+            result: dict[str, Any] = {}
+            for raw_reference in reference.split(';'):
+                ref = raw_reference.strip()
+                if not ref:
+                    raise ValueError("Invalid empty reference.")
+                try:
+                    book_reference = self.__get.ref(ref, abbreviation)
+                except ValueError as error:
+                    raise ValueError(f"Invalid reference '{ref}'.") from error
+                self.__set_verse(abbreviation, book_reference, result)
+            return result
 
     def scripture(self, reference: str, abbreviation: str | None = 'kjv') -> str:
         """Return :meth:`select` output encoded as JSON."""
@@ -149,18 +186,29 @@ class GetBible:
         :meth:`select`. ``query`` and ``matches`` add search-specific metadata
         without changing the established scripture objects.
         """
-        code = self._validated_translation_code(abbreviation)
-        parsed_criteria = SearchBible.from_value(criteria)
-        try:
-            corpus = self._search_corpus(code)
-        except RepositoryResourceNotFound as error:
-            raise FileNotFoundError(f"Translation ({code}) not found.") from error
-        engine = SearchEngine(
-            corpus,
-            lambda book: self.__get.book_number(book, code),
-        )
-        hits, total = engine.search(query, parsed_criteria)
-        return self._search_response(query, code, parsed_criteria, corpus, hits, total)
+        with self.source_operation():
+            code = self._validated_translation_code(abbreviation)
+            parsed_criteria = SearchBible.from_value(criteria)
+            try:
+                corpus = self._search_corpus(code)
+            except RepositoryResourceNotFound as error:
+                raise FileNotFoundError(f"Translation ({code}) not found.") from error
+            engine = SearchEngine(
+                corpus,
+                lambda book: self.__get.book_number(book, code),
+                self.search_limits,
+            )
+            hits, total = engine.search(query, parsed_criteria)
+            return self._search_response(
+                query,
+                code,
+                parsed_criteria,
+                corpus,
+                hits,
+                total,
+                engine.execution_info,
+                self.search_limits.max_response_bytes,
+            )
 
     def search_json(
         self,
@@ -187,22 +235,23 @@ class GetBible:
         only. Call it before a pre-fork server creates workers when copy-on-write
         sharing is desired.
         """
-        code = self._validated_translation_code(abbreviation)
-        criteria = SearchBible(
-            case_sensitive=case_sensitive,
-            diacritics=diacritics,
-            limit=1,
-        )
-        try:
-            corpus = self._search_corpus(code)
-        except RepositoryResourceNotFound as error:
-            raise FileNotFoundError(f"Translation ({code}) not found.") from error
-        corpus.index(criteria.case_sensitive, criteria.diacritics)
-        return {"abbreviation": code, **corpus.cache_info()}
+        with self.source_operation():
+            code = self._validated_translation_code(abbreviation)
+            criteria = SearchBible(
+                case_sensitive=case_sensitive,
+                diacritics=diacritics,
+                limit=1,
+            )
+            try:
+                corpus = self._search_corpus(code)
+            except RepositoryResourceNotFound as error:
+                raise FileNotFoundError(f"Translation ({code}) not found.") from error
+            corpus.index(criteria.case_sensitive, criteria.diacritics)
+            return {"abbreviation": code, **corpus.cache_info()}
 
     def cache_info(self) -> dict[str, Any]:
         """Return bounded-cache state and counters without exposing payloads."""
-        with self._cache_guard:
+        with self.source_operation(), self._cache_guard:
             corpora = {
                 code: corpus.cache_info()
                 for code, corpus in self._search_corpora.items()
@@ -226,7 +275,22 @@ class GetBible:
             "search_corpora": search_corpora,
             "translation_cache": self._translation_cache.cache_info(),
             "active_resource_locks": self._resource_locks.size,
+            "source": self._source_coordinator.info(),
         }
+
+    @contextmanager
+    def source_operation(self) -> Iterator[SourceGeneration]:
+        """Hold one source generation across an external cache transaction."""
+        with self._source_coordinator.source_operation() as generation:
+            yield generation
+
+    def transition_source(
+        self,
+        revision: str,
+        purge_callback: PurgeCallback | None = None,
+    ) -> dict[str, str | int | float]:
+        """Activate an immutable mirror revision and invalidate every worker cache."""
+        return self._source_coordinator.transition(revision, purge_callback).to_dict()
 
     def close(self) -> None:
         """Close repository HTTP sessions during application shutdown."""
@@ -250,7 +314,7 @@ class GetBible:
             return False
 
         key = f"books:{code}"
-        with self._resource_locks.hold(key):
+        with self.source_operation(), self._resource_locks.hold(key):
             with self._cache_guard:
                 entry = self.__books_cache.get(code)
             if entry is not None and self._is_fresh(entry):
@@ -340,14 +404,21 @@ class GetBible:
         corpus: TranslationCorpus,
         hits: list[SearchHit],
         total: int,
+        execution_info: dict[str, int | float | bool],
+        max_response_bytes: int,
     ) -> dict[str, Any]:
         results: dict[str, Any] = {}
         matches: list[dict[str, Any]] = []
+        accumulated_bytes = GetBible._json_bytes(corpus.translation_metadata)
+        if accumulated_bytes > max_response_bytes:
+            raise SearchLimitError(
+                "Search translation metadata exceeds the configured response-volume budget."
+            )
         for hit in hits:
             record = hit.record
             cache_key = f"{abbreviation}_{record.book_nr}_{record.chapter}"
             if cache_key not in results:
-                results[cache_key] = dict(corpus.chapter_metadata)
+                results[cache_key] = deepcopy(corpus.chapter_metadata)
                 results[cache_key].update(
                     {
                         "book_nr": record.book_nr,
@@ -358,27 +429,34 @@ class GetBible:
                         "verses": [],
                     }
                 )
+                accumulated_bytes += GetBible._json_bytes(results[cache_key])
             results[cache_key]["ref"].append(record.reference)
-            results[cache_key]["verses"].append(record.verse)
-            matches.append(
-                {
-                    "reference": record.reference,
-                    "book_nr": record.book_nr,
-                    "chapter": record.chapter,
-                    "verse": record.verse["verse"],
-                    "score": hit.score,
-                    "occurrences": hit.occurrences,
-                    "terms": list(hit.terms),
-                }
-            )
+            verse = deepcopy(record.verse)
+            match = {
+                "reference": record.reference,
+                "book_nr": record.book_nr,
+                "chapter": record.chapter,
+                "verse": record.verse["verse"],
+                "score": hit.score,
+                "occurrences": hit.occurrences,
+                "terms": list(hit.terms),
+            }
+            accumulated_bytes += GetBible._json_bytes(verse)
+            accumulated_bytes += GetBible._json_bytes(match)
+            if accumulated_bytes > max_response_bytes:
+                raise SearchLimitError(
+                    "Search results exceed the configured response-volume budget."
+                )
+            results[cache_key]["verses"].append(verse)
+            matches.append(match)
 
         returned = len(hits)
         checked_at, stale = corpus.cache_state()
-        return {
+        response = {
             "query": {
                 "text": query,
                 "criteria": criteria.to_dict(),
-                "translation": corpus.translation_metadata,
+                "translation": deepcopy(corpus.translation_metadata),
                 "sha": corpus.sha,
                 "total": total,
                 "offset": criteria.offset,
@@ -389,10 +467,34 @@ class GetBible:
                     "checked_at": checked_at,
                     "stale": stale,
                 },
+                "cost": {
+                    "work_units": execution_info["work_units"],
+                    "deadline_seconds": execution_info["deadline_seconds"],
+                    "expensive": execution_info["expensive"],
+                },
             },
             "results": results,
             "matches": matches,
         }
+        response_bytes = len(
+            json.dumps(
+                response,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        if response_bytes > max_response_bytes:
+            raise SearchLimitError(
+                f"Search response requires {response_bytes} bytes; the configured maximum "
+                f"is {max_response_bytes}."
+            )
+        return response
+
+    @staticmethod
+    def _json_bytes(value: Any) -> int:
+        return len(
+            json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        )
 
     def __set_verse(
         self,
@@ -414,16 +516,18 @@ class GetBible:
             if cache_key in result:
                 existing_verses = {str(item["verse"]) for item in result[cache_key]["verses"]}
                 if str(verse) not in existing_verses:
-                    result[cache_key]["verses"].append(verse_info)
+                    result[cache_key]["verses"].append(deepcopy(verse_info))
                 if book_ref.reference not in result[cache_key]["ref"]:
                     result[cache_key]["ref"].append(book_ref.reference)
                 continue
 
             result[cache_key] = {
-                key: value for key, value in chapter_data.items() if key != "verses"
+                key: deepcopy(value)
+                for key, value in chapter_data.items()
+                if key != "verses"
             }
             result[cache_key]["ref"] = [book_ref.reference]
-            result[cache_key]["verses"] = [verse_info]
+            result[cache_key]["verses"] = [deepcopy(verse_info)]
 
     def _chapter(self, abbreviation: str, book: int, chapter: int) -> dict[str, Any]:
         cache_key = f"{abbreviation}_{book}_{chapter}"
@@ -439,18 +543,16 @@ class GetBible:
             with self._cache_guard:
                 self._cache_stats["chapters"].misses += 1
 
-            if entry is not None and entry.sha:
-                try:
-                    remote_sha = self._repository.fetch_text(
-                        f"{abbreviation}/{book}/{chapter}.sha"
-                    ).strip()
-                except RepositoryResourceNotFound:
-                    remote_sha = ""
-                if remote_sha and remote_sha == entry.sha:
-                    entry.loaded_at = time.monotonic()
-                    with self._cache_guard:
-                        self.__chapters_cache.move_to_end(cache_key)
-                    return entry.data
+            checksum_path = f"{abbreviation}/{book}/{chapter}.sha"
+            remote_sha = self._published_checksum(
+                checksum_path,
+                f"chapter {abbreviation} {book}:{chapter}",
+            )
+            if entry is not None and entry.sha and remote_sha == entry.sha:
+                entry.loaded_at = time.monotonic()
+                with self._cache_guard:
+                    self.__chapters_cache.move_to_end(cache_key)
+                return entry.data
 
             relative_path = f"{abbreviation}/{book}/{chapter}.json"
             try:
@@ -459,18 +561,28 @@ class GetBible:
                 raise FileNotFoundError(
                     f"Chapter:{chapter} in book:{book} for {abbreviation} not found."
                 ) from error
+            if self._require_checksums and not remote_sha:
+                raise RepositoryResponseError(
+                    f"Chapter {abbreviation} {book}:{chapter} has no required checksum."
+                )
             try:
                 chapter_data = json.loads(raw)
             except (UnicodeDecodeError, json.JSONDecodeError) as error:
                 raise CacheIntegrityError(
                     f"Invalid chapter JSON for {abbreviation} {book}:{chapter}."
                 ) from error
-            if not isinstance(chapter_data, dict) or not isinstance(
-                chapter_data.get("verses"), list
-            ):
+            actual_sha = hashlib.sha1(raw, usedforsecurity=False).hexdigest()
+            if remote_sha and actual_sha != remote_sha:
                 raise CacheIntegrityError(
-                    f"Invalid chapter structure for {abbreviation} {book}:{chapter}."
+                    f"Checksum mismatch for chapter {abbreviation} {book}:{chapter}: "
+                    f"expected {remote_sha}, received {actual_sha}."
                 )
+            TranslationCache.validate_chapter_payload(
+                chapter_data,
+                abbreviation,
+                book,
+                chapter,
+            )
 
             chapter_data["verses"] = {
                 str(verse["verse"]): verse for verse in chapter_data["verses"]
@@ -478,7 +590,7 @@ class GetBible:
             loaded = _CacheEntry(
                 data=chapter_data,
                 loaded_at=time.monotonic(),
-                sha=hashlib.sha1(raw, usedforsecurity=False).hexdigest(),
+                sha=actual_sha,
             )
             with self._cache_guard:
                 self._put_bounded(
@@ -489,6 +601,26 @@ class GetBible:
                     "chapters",
                 )
             return chapter_data
+
+    def _published_checksum(self, relative_path: str, label: str) -> str:
+        try:
+            checksum = self._repository.fetch_text(relative_path).strip().lower()
+        except RepositoryResourceNotFound:
+            return ""
+        if not TranslationCache._valid_sha(checksum):
+            raise RepositoryResponseError(f"{label.capitalize()} publishes an invalid checksum.")
+        return checksum
+
+    def _invalidate_worker_caches(self, generation: SourceGeneration) -> None:
+        with self._cache_guard:
+            self.__books_cache.clear()
+            self.__chapters_cache.clear()
+            self._search_corpora.clear()
+        self._translation_cache.set_source_generation(generation.generation)
+        self._on_source_generation_changed(generation)
+
+    def _on_source_generation_changed(self, generation: SourceGeneration) -> None:
+        """Allow hardened subclasses to invalidate additional process-local state."""
 
     def __check_translation(self, abbreviation: str) -> None:
         if not self.valid_translation(abbreviation):

--- a/src/getbible/hardened.py
+++ b/src/getbible/hardened.py
@@ -14,11 +14,11 @@ from ._keyed_locks import KeyedLockPool
 from .exceptions import (
     ReferenceValidationError,
     RequestLimitError,
-    SearchValidationError,
     TranslationNotFoundError,
 )
 from .getbible import GetBible as _BaseGetBible
-from .search import SearchBible
+from .search import SearchBible, SearchLimits, validate_search_request
+from .source_generation import PurgeCallback, SourceGeneration
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,8 +71,17 @@ class GetBible(_BaseGetBible):
         negative_translation_cache_limit: int = 64,
         negative_translation_ttl: float = 300.0,
         max_response_bytes: int = 128 * 1024 * 1024,
+        require_checksums: bool | None = None,
+        source_purge_callback: PurgeCallback | None = None,
+        search_limits: SearchLimits | None = None,
     ) -> None:
         self.request_limits = request_limits or RequestLimits()
+        if search_limits is None:
+            search_limits = SearchLimits(
+                max_offset=self.request_limits.max_search_offset,
+                max_books=self.request_limits.max_search_books,
+                max_exclusions=self.request_limits.max_search_exclusions,
+            )
         self._negative_translation_cache_limit = self._bounded_integer(
             "negative_translation_cache_limit",
             negative_translation_cache_limit,
@@ -99,6 +108,9 @@ class GetBible(_BaseGetBible):
             search_corpus_limit=search_corpus_limit,
             translation_cache_limit=translation_cache_limit,
             cache_ttl_jitter=cache_ttl_jitter,
+            require_checksums=require_checksums,
+            source_purge_callback=source_purge_callback,
+            search_limits=search_limits,
         )
         self._repository.max_response_bytes = self._bounded_integer(
             "max_response_bytes",
@@ -159,28 +171,29 @@ class GetBible(_BaseGetBible):
         criteria: SearchBible | dict[str, Any] | str | None = None,
     ) -> dict[str, Any]:
         """Search only after cheap input and criteria checks have passed."""
-        if not isinstance(query, str):
-            raise SearchValidationError("Search query must be a string.")
-        stripped_query = query.strip()
-        if not stripped_query:
-            raise SearchValidationError("Search query cannot be empty.")
-        if len(stripped_query) > 500:
-            raise RequestLimitError("Search query cannot exceed 500 characters.")
         parsed = SearchBible.from_value(criteria)
-        if parsed.offset > self.request_limits.max_search_offset:
-            raise RequestLimitError(
-                f"Search offset cannot exceed {self.request_limits.max_search_offset}."
-            )
-        if len(parsed.books) > self.request_limits.max_search_books:
-            raise RequestLimitError(
-                f"Search cannot select more than {self.request_limits.max_search_books} books."
-            )
-        if len(parsed.exclude) > self.request_limits.max_search_exclusions:
-            raise RequestLimitError(
-                "Search cannot contain more than "
-                f"{self.request_limits.max_search_exclusions} exclusions."
-            )
-        return super().search(stripped_query, abbreviation, parsed)
+        stripped_query, *_ = validate_search_request(query, parsed, self.search_limits)
+        code = self._validated_translation_code(abbreviation)
+        if not self.valid_translation(code):
+            raise TranslationNotFoundError(f"Translation ({code}) not found.")
+        return super().search(stripped_query, code, parsed)
+
+    def warm_translation(
+        self,
+        abbreviation: str | None = "kjv",
+        *,
+        case_sensitive: bool = False,
+        diacritics: str = "sensitive",
+    ) -> dict[str, Any]:
+        """Validate availability before any persistent translation-cache work."""
+        code = self._validated_translation_code(abbreviation)
+        if not self.valid_translation(code):
+            raise TranslationNotFoundError(f"Translation ({code}) not found.")
+        return super().warm_translation(
+            code,
+            case_sensitive=case_sensitive,
+            diacritics=diacritics,
+        )
 
     def cache_info(self) -> dict[str, Any]:
         """Return base telemetry plus request and negative-cache limits."""
@@ -197,6 +210,7 @@ class GetBible(_BaseGetBible):
                 "evictions": self._negative_translation_evictions,
             }
         state["request_limits"] = asdict(self.request_limits)
+        state["search_limits"] = self.search_limits.to_dict()
         state["active_translation_validation_locks"] = self._translation_validation_locks.size
         state["repository_max_response_bytes"] = self._repository.max_response_bytes
         return state
@@ -205,6 +219,10 @@ class GetBible(_BaseGetBible):
         with self._missing_translations_guard:
             self._missing_translations.clear()
         super().close()
+
+    def _on_source_generation_changed(self, generation: SourceGeneration) -> None:
+        with self._missing_translations_guard:
+            self._missing_translations.clear()
 
     def _validated_references(self, reference: str, abbreviation: str) -> None:
         if not isinstance(reference, str):

--- a/src/getbible/search.py
+++ b/src/getbible/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 import unicodedata
 from array import array
 from collections import Counter
@@ -13,7 +14,12 @@ from typing import Any, ClassVar
 
 import regex
 
-from .exceptions import CacheIntegrityError, SearchValidationError
+from .exceptions import (
+    CacheIntegrityError,
+    SearchDeadlineExceeded,
+    SearchLimitError,
+    SearchValidationError,
+)
 from .translation_cache import TranslationSnapshot
 
 _WORD_CHARACTER_CLASS = r"\p{L}\p{M}\p{N}"
@@ -23,6 +29,93 @@ _VALID_MATCH = frozenset({"whole_word", "substring"})
 _VALID_SCOPE = frozenset({"bible", "old_testament", "new_testament", "deuterocanon"})
 _VALID_DIACRITICS = frozenset({"sensitive", "insensitive"})
 _VALID_SORT = frozenset({"canonical", "relevance"})
+
+
+@dataclass(frozen=True, slots=True)
+class SearchLimits:
+    """Deterministic per-search work, output, filter, and deadline budgets."""
+
+    max_work_units: int = 50_000_000
+    max_response_bytes: int = 4 * 1024 * 1024
+    max_query_length: int = 500
+    max_query_terms: int = 64
+    min_substring_length: int = 3
+    max_books: int = 83
+    max_exclusions: int = 32
+    max_exclusion_terms: int = 64
+    max_offset: int = 10_000
+    max_limit: int = 1_000
+    deadline_seconds: float = 5.0
+    deadline_check_interval: int = 256
+
+    def __post_init__(self) -> None:
+        integer_fields = (
+            "max_work_units",
+            "max_response_bytes",
+            "max_query_length",
+            "max_query_terms",
+            "min_substring_length",
+            "max_books",
+            "max_exclusions",
+            "max_exclusion_terms",
+            "max_limit",
+            "deadline_check_interval",
+        )
+        for name in integer_fields:
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} must be a positive integer.")
+        if (
+            not isinstance(self.max_offset, int)
+            or isinstance(self.max_offset, bool)
+            or self.max_offset < 0
+        ):
+            raise ValueError("max_offset must be a non-negative integer.")
+        if not isinstance(self.deadline_seconds, int | float) or isinstance(
+            self.deadline_seconds, bool
+        ):
+            raise TypeError("deadline_seconds must be numeric.")
+        if not 0.001 <= float(self.deadline_seconds) <= 300.0:
+            raise ValueError("deadline_seconds must be between 0.001 and 300 seconds.")
+
+    def to_dict(self) -> dict[str, int | float]:
+        return {name: getattr(self, name) for name in self.__dataclass_fields__}
+
+
+class SearchBudget:
+    """One request's deterministic work reservation and cooperative deadline."""
+
+    def __init__(self, limits: SearchLimits) -> None:
+        self.limits = limits
+        self.started_at = time.monotonic()
+        self.deadline = self.started_at + float(limits.deadline_seconds)
+        self.work_units = 0
+
+    def reserve(self, units: int) -> None:
+        if not isinstance(units, int) or isinstance(units, bool) or units < 0:
+            raise ValueError("Search work units must be a non-negative integer.")
+        if units > self.limits.max_work_units:
+            raise SearchLimitError(
+                "Search requires "
+                f"{units} work units; the configured maximum is "
+                f"{self.limits.max_work_units}."
+            )
+        self.work_units = max(self.work_units, units)
+        self.check_deadline()
+
+    def checkpoint(self, iteration: int = 0) -> None:
+        if iteration % self.limits.deadline_check_interval == 0:
+            self.check_deadline()
+
+    def check_deadline(self) -> None:
+        if time.monotonic() >= self.deadline:
+            raise SearchDeadlineExceeded(
+                f"Search exceeded its {float(self.limits.deadline_seconds):g}-second deadline."
+            )
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return max(0.0, time.monotonic() - self.started_at)
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,6 +215,20 @@ class SearchBible:
     def with_pagination(self, limit: int, offset: int) -> SearchBible:
         return replace(self, limit=limit, offset=offset)
 
+    @property
+    def expensive(self) -> bool:
+        """Classify strict-rate-tier searches without loading a translation."""
+        return (
+            self.match == "substring"
+            or self.words in {"any", "phrase"}
+            or self.proximity is not None
+            or self.sort == "relevance"
+            or bool(self.exclude)
+            or self.diacritics == "insensitive"
+            or self.offset > 1_000
+            or self.limit > 100
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "words": self.words,
@@ -208,6 +315,7 @@ class SearchIndex:
     texts: tuple[str, ...]
     postings: dict[str, array]
     document_frequency: dict[str, int]
+    build_work_units: int
 
 
 class TranslationCorpus:
@@ -230,6 +338,11 @@ class TranslationCorpus:
             if key in snapshot.data
         }
         self.records = self._build_records(snapshot.data)
+        # Charge index construction from immutable corpus characteristics so
+        # the budget can reject it before normalization and tokenization begin.
+        self.index_build_work_units = len(self.records) + sum(
+            len(record.text) * 2 for record in self.records
+        )
         self.available_books = frozenset(record.book_nr for record in self.records)
         self.book_names = self._build_book_names(self.records)
         self._variants: dict[tuple[bool, str], SearchIndex] = {}
@@ -269,7 +382,12 @@ class TranslationCorpus:
             "indexes": variants,
         }
 
-    def index(self, case_sensitive: bool, diacritics: str) -> SearchIndex:
+    def index(
+        self,
+        case_sensitive: bool,
+        diacritics: str,
+        budget: SearchBudget | None = None,
+    ) -> SearchIndex:
         key = (case_sensitive, diacritics)
         index = self._variants.get(key)
         if index is None:
@@ -283,6 +401,8 @@ class TranslationCorpus:
                     postings: dict[str, array] = {}
                     document_frequency: dict[str, int] = {}
                     for ordinal, text in enumerate(texts):
+                        if budget is not None:
+                            budget.checkpoint(ordinal)
                         tokens = _TOKEN.findall(text)
                         for token in tokens:
                             postings.setdefault(token, array("I")).append(ordinal)
@@ -292,6 +412,7 @@ class TranslationCorpus:
                         texts=texts,
                         postings=postings,
                         document_frequency=document_frequency,
+                        build_work_units=self.index_build_work_units,
                     )
                     self._variants[key] = index
         return index
@@ -360,6 +481,73 @@ class TranslationCorpus:
         return names
 
 
+def validate_search_request(
+    query: object,
+    criteria: SearchBible,
+    limits: SearchLimits,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """Validate all corpus-independent search limits before repository access."""
+    if not isinstance(query, str):
+        raise SearchValidationError("Search query must be a string.")
+    stripped_query = query.strip()
+    if not stripped_query:
+        raise SearchValidationError("Search query cannot be empty.")
+    if len(stripped_query) > limits.max_query_length:
+        raise SearchValidationError(
+            f"Search query cannot exceed {limits.max_query_length} characters."
+        )
+    if criteria.limit > limits.max_limit:
+        raise SearchLimitError(f"Search limit cannot exceed {limits.max_limit}.")
+    if criteria.offset > limits.max_offset:
+        raise SearchLimitError(f"Search offset cannot exceed {limits.max_offset}.")
+    if len(criteria.books) > limits.max_books:
+        raise SearchLimitError(
+            f"Search cannot select more than {limits.max_books} books."
+        )
+    if len(criteria.exclude) > limits.max_exclusions:
+        raise SearchLimitError(
+            f"Search cannot contain more than {limits.max_exclusions} exclusions."
+        )
+
+    normalized_query = normalize_text(
+        stripped_query,
+        criteria.case_sensitive,
+        criteria.diacritics,
+    )
+    query_terms = tuple(_TOKEN.findall(normalized_query))
+    if not query_terms:
+        raise SearchValidationError("Search query must contain letters or numbers.")
+    if len(query_terms) > limits.max_query_terms:
+        raise SearchValidationError(
+            f"Search query cannot exceed {limits.max_query_terms} terms."
+        )
+    if criteria.words != "phrase":
+        query_terms = tuple(dict.fromkeys(query_terms))
+    excluded = tuple(
+        normalize_text(term, criteria.case_sensitive, criteria.diacritics)
+        for term in criteria.exclude
+    )
+    excluded_terms = tuple(token for value in excluded for token in _TOKEN.findall(value))
+    if len(excluded_terms) > limits.max_exclusion_terms:
+        raise SearchLimitError(
+            "Search exclusions cannot contain more than "
+            f"{limits.max_exclusion_terms} terms."
+        )
+    if criteria.match == "substring":
+        searched_values = (
+            (normalized_query,) if criteria.words == "phrase" else query_terms
+        )
+        if any(
+            len(term) < limits.min_substring_length
+            for term in (*searched_values, *excluded_terms)
+        ):
+            raise SearchValidationError(
+                "Substring search terms must contain at least "
+                f"{limits.min_substring_length} characters."
+            )
+    return stripped_query, normalized_query, query_terms, excluded, excluded_terms
+
+
 class SearchEngine:
     """Execute criteria against a loaded translation corpus."""
 
@@ -370,43 +558,43 @@ class SearchEngine:
         self,
         corpus: TranslationCorpus,
         book_number: Callable[[str], int | None],
+        limits: SearchLimits | None = None,
     ) -> None:
         self.corpus = corpus
         self.book_number = book_number
+        self.limits = limits or SearchLimits()
+        self.execution_info: dict[str, int | float | bool] = {}
 
     def search(
         self,
         query: str,
         criteria: SearchBible,
     ) -> tuple[list[SearchHit], int]:
-        if not isinstance(query, str):
-            raise SearchValidationError("Search query must be a string.")
-        query = query.strip()
-        if not query:
-            raise SearchValidationError("Search query cannot be empty.")
-        if len(query) > self.MAX_QUERY_LENGTH:
-            raise SearchValidationError(
-                f"Search query cannot exceed {self.MAX_QUERY_LENGTH} characters."
-            )
-
-        normalized_query = normalize_text(
-            query, criteria.case_sensitive, criteria.diacritics
-        )
-        query_terms = tuple(_TOKEN.findall(normalized_query))
-        if not query_terms:
-            raise SearchValidationError("Search query must contain letters or numbers.")
-        if len(query_terms) > self.MAX_QUERY_TERMS:
-            raise SearchValidationError(
-                f"Search query cannot exceed {self.MAX_QUERY_TERMS} terms."
-            )
-        if criteria.words != "phrase":
-            query_terms = tuple(dict.fromkeys(query_terms))
-        excluded = tuple(
-            normalize_text(term, criteria.case_sensitive, criteria.diacritics)
-            for term in criteria.exclude
+        budget = SearchBudget(self.limits)
+        query, normalized_query, query_terms, excluded, excluded_terms = (
+            validate_search_request(query, criteria, self.limits)
         )
         book_filter = self._book_filter(criteria)
-        index = self.corpus.index(criteria.case_sensitive, criteria.diacritics)
+        budget.reserve(
+            self.corpus.index_build_work_units
+            + len(self.corpus.records)
+            + (criteria.limit * 8)
+        )
+        index = self.corpus.index(
+            criteria.case_sensitive,
+            criteria.diacritics,
+            budget,
+        )
+        budget.reserve(
+            self._estimate_work(
+                index,
+                query_terms,
+                excluded_terms,
+                book_filter,
+                criteria,
+                budget,
+            )
+        )
         if (
             len(query_terms) == 1
             and criteria.match == "whole_word"
@@ -414,18 +602,21 @@ class SearchEngine:
             and criteria.proximity is None
             and criteria.sort == "canonical"
         ):
-            return self._single_term_search(
-                index, query_terms[0], book_filter, criteria
+            result = self._single_term_search(
+                index, query_terms[0], book_filter, criteria, budget
             )
+            self._finish_execution(budget, criteria)
+            return result
 
-        matcher = _Matcher(criteria, normalized_query, query_terms, excluded)
+        matcher = _Matcher(criteria, normalized_query, query_terms, excluded, budget)
         eligible = None
         if book_filter != self.corpus.available_books:
-            eligible = frozenset(
-                record.ordinal
-                for record in self.corpus.records
-                if record.book_nr in book_filter
-            )
+            selected_ordinals: set[int] = set()
+            for ordinal, record in enumerate(self.corpus.records):
+                budget.checkpoint(ordinal)
+                if record.book_nr in book_filter:
+                    selected_ordinals.add(record.ordinal)
+            eligible = frozenset(selected_ordinals)
         matched = matcher.search(index, eligible)
         hits = [
             SearchHit(self.corpus.records[ordinal], score, occurrences, terms)
@@ -435,7 +626,9 @@ class SearchEngine:
         if criteria.sort == "relevance":
             hits.sort(key=lambda hit: (-hit.score, hit.record.ordinal))
         total = len(hits)
-        return hits[criteria.offset:criteria.offset + criteria.limit], total
+        result = hits[criteria.offset:criteria.offset + criteria.limit], total
+        self._finish_execution(budget, criteria)
+        return result
 
     def _single_term_search(
         self,
@@ -443,6 +636,7 @@ class SearchEngine:
         term: str,
         book_filter: frozenset[int],
         criteria: SearchBible,
+        budget: SearchBudget,
     ) -> tuple[list[SearchHit], int]:
         selected: list[SearchHit] = []
         whole_corpus = book_filter == self.corpus.available_books
@@ -450,6 +644,7 @@ class SearchEngine:
         matched_position = 0
         page_end = criteria.offset + criteria.limit
         for ordinal, occurrences_group in groupby(index.postings.get(term, ())):
+            budget.checkpoint(matched_position)
             occurrences = sum(1 for _ in occurrences_group)
             record = self.corpus.records[ordinal]
             if record.book_nr not in book_filter:
@@ -469,6 +664,50 @@ class SearchEngine:
         if not whole_corpus:
             total = matched_position
         return selected, total
+
+    def _estimate_work(
+        self,
+        index: SearchIndex,
+        query_terms: tuple[str, ...],
+        excluded_terms: tuple[str, ...],
+        book_filter: frozenset[int],
+        criteria: SearchBible,
+        budget: SearchBudget,
+    ) -> int:
+        terms = (*query_terms, *excluded_terms)
+        units = index.build_work_units
+        if book_filter != self.corpus.available_books:
+            units += len(self.corpus.records)
+
+        if criteria.match == "substring":
+            for position, (token, ordinals) in enumerate(index.postings.items()):
+                budget.checkpoint(position)
+                for term in terms:
+                    units += 1 + min(len(token), len(term))
+                    if term in token:
+                        units += len(ordinals)
+            if criteria.words == "phrase":
+                units += sum(len(text) for text in index.texts)
+        else:
+            units += sum(len(index.postings.get(term, ())) for term in terms)
+            if criteria.words == "phrase":
+                units += sum(len(index.postings.get(term, ())) for term in query_terms)
+
+        if criteria.proximity is not None:
+            units += len(self.corpus.records) * max(1, len(query_terms))
+        if criteria.sort == "relevance":
+            units += len(self.corpus.records) * max(1, len(self.corpus.records).bit_length())
+        units += criteria.limit * 8
+        return units
+
+    def _finish_execution(self, budget: SearchBudget, criteria: SearchBible) -> None:
+        budget.check_deadline()
+        self.execution_info = {
+            "work_units": budget.work_units,
+            "deadline_seconds": float(self.limits.deadline_seconds),
+            "elapsed_seconds": budget.elapsed_seconds,
+            "expensive": criteria.expensive,
+        }
 
     def _book_filter(self, criteria: SearchBible) -> frozenset[int]:
         if criteria.scope == "old_testament":
@@ -493,11 +732,13 @@ class _Matcher:
         query: str,
         terms: tuple[str, ...],
         excluded: tuple[str, ...],
+        budget: SearchBudget,
     ) -> None:
         self.criteria = criteria
         self.query = query
         self.terms = terms
         self.excluded = excluded
+        self.budget = budget
         self.excluded_tokens = tuple(
             dict.fromkeys(
                 token for value in excluded for token in _TOKEN.findall(value)
@@ -516,15 +757,17 @@ class _Matcher:
             matches = self._word_matches(index, eligible)
 
         excluded = self._excluded_ordinals(index)
-        for ordinal in excluded:
+        for position, ordinal in enumerate(excluded):
+            self.budget.checkpoint(position)
             matches.pop(ordinal, None)
 
         if self.criteria.proximity is not None:
-            matches = {
-                ordinal: match
-                for ordinal, match in matches.items()
-                if self._within_proximity(index.texts[ordinal])
-            }
+            nearby: dict[int, tuple[int, int, tuple[str, ...]]] = {}
+            for position, (ordinal, match) in enumerate(matches.items()):
+                self.budget.checkpoint(position)
+                if self._within_proximity(index.texts[ordinal]):
+                    nearby[ordinal] = match
+            matches = nearby
         return matches
 
     def _phrase_matches(
@@ -543,7 +786,8 @@ class _Matcher:
                 candidates.intersection_update(eligible)
 
         matches: dict[int, tuple[int, int, tuple[str, ...]]] = {}
-        for ordinal in candidates:
+        for position, ordinal in enumerate(candidates):
+            self.budget.checkpoint(position)
             text = index.texts[ordinal]
             occurrences = (
                 text.count(self.query)
@@ -572,7 +816,8 @@ class _Matcher:
             candidates.intersection_update(eligible)
 
         matches: dict[int, tuple[int, int, tuple[str, ...]]] = {}
-        for ordinal in candidates:
+        for position, ordinal in enumerate(candidates):
+            self.budget.checkpoint(position)
             counts = tuple(values.get(ordinal, 0) for values in per_term)
             terms = tuple(
                 term
@@ -587,14 +832,16 @@ class _Matcher:
         if self.criteria.match == "whole_word":
             return Counter(index.postings.get(term, ()))
         counts: Counter[int] = Counter()
-        for token, ordinals in index.postings.items():
+        for position, (token, ordinals) in enumerate(index.postings.items()):
+            self.budget.checkpoint(position)
             if term in token:
                 counts.update(ordinals)
         return counts
 
     def _excluded_ordinals(self, index: SearchIndex) -> set[int]:
         excluded: set[int] = set()
-        for term in self.excluded_tokens:
+        for position, term in enumerate(self.excluded_tokens):
+            self.budget.checkpoint(position)
             excluded.update(self._posting_counts(index, term))
         return excluded
 
@@ -608,6 +855,7 @@ class _Matcher:
         satisfied = 0
         required = len(wanted)
         for right, token in enumerate(positions):
+            self.budget.checkpoint(right)
             if token in wanted:
                 counts[token] = counts.get(token, 0) + 1
                 if counts[token] == wanted[token]:

--- a/src/getbible/source_generation.py
+++ b/src/getbible/source_generation.py
@@ -1,0 +1,302 @@
+"""Atomic source generations for multi-worker cache coordination."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+
+from .exceptions import CacheIntegrityError
+
+try:  # pragma: no cover - exercised by Linux CI and production deployments.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows uses the process-local barrier.
+    fcntl = None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceGeneration:
+    """One committed repository generation and its stable cache namespace."""
+
+    namespace: str
+    generation: int
+    revision: str
+    updated_at: float
+
+    @property
+    def cache_namespace(self) -> str:
+        """Return a response-cache prefix that changes only after a transition."""
+        return f"{self.namespace}:g{self.generation}"
+
+    def to_dict(self) -> dict[str, str | int | float]:
+        return {**asdict(self), "cache_namespace": self.cache_namespace}
+
+
+PurgeCallback = Callable[[SourceGeneration, SourceGeneration], None]
+InvalidateCallback = Callable[[SourceGeneration], None]
+
+
+class _ReaderWriterBarrier:
+    """Writer-preferring reader/writer barrier for threads in one process."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.Lock())
+        self._readers = 0
+        self._writer = False
+        self._waiting_writers = 0
+
+    @contextmanager
+    def read(self) -> Iterator[None]:
+        with self._condition:
+            while self._writer or self._waiting_writers:
+                self._condition.wait()
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._condition.notify_all()
+
+    @contextmanager
+    def write(self) -> Iterator[None]:
+        with self._condition:
+            self._waiting_writers += 1
+            try:
+                while self._writer or self._readers:
+                    self._condition.wait()
+                self._writer = True
+            finally:
+                self._waiting_writers -= 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._writer = False
+                self._condition.notify_all()
+
+
+class SourceCoordinator:
+    """Coordinate source transitions and cache invalidation across workers.
+
+    Readers hold a shared operating-system lock for the complete operation.
+    Transitions hold the exclusive form of that lock, serialize the purge
+    callback, and atomically commit the new manifest only after purge succeeds.
+    """
+
+    MANIFEST_VERSION = 1
+    MAX_REVISION_LENGTH = 256
+
+    def __init__(
+        self,
+        cache_root: Path,
+        source: str,
+        version: str,
+        invalidate_callback: InvalidateCallback,
+        purge_callback: PurgeCallback | None = None,
+    ) -> None:
+        self.namespace = hashlib.sha256(f"{source}|{version}".encode()).hexdigest()[:16]
+        self.directory = cache_root / self.namespace / version
+        self.manifest_path = self.directory / "source-generation.json"
+        self.transition_lock_path = self.directory / "source-transition.lock"
+        self.barrier_path = self.directory / "source-transition.barrier"
+        self.invalidate_callback = invalidate_callback
+        self.purge_callback = purge_callback
+        self._barrier = _ReaderWriterBarrier()
+        self._state_guard = threading.Lock()
+        self._thread_local = threading.local()
+        self._observed = self._read_manifest()
+
+    @contextmanager
+    def source_operation(self) -> Iterator[SourceGeneration]:
+        """Hold a stable generation across source reads and cache transactions."""
+        depth = getattr(self._thread_local, "operation_depth", 0)
+        if depth:
+            self._thread_local.operation_depth = depth + 1
+            try:
+                yield self._thread_local.operation_state
+            finally:
+                self._thread_local.operation_depth -= 1
+            return
+
+        self.synchronize()
+        with self._barrier.read(), self._file_barrier(shared=True):
+            state = self._read_manifest()
+            self._thread_local.operation_depth = 1
+            self._thread_local.operation_state = state
+            try:
+                yield state
+            finally:
+                del self._thread_local.operation_state
+                del self._thread_local.operation_depth
+
+    def synchronize(self) -> SourceGeneration:
+        """Invalidate this worker when another worker committed a generation."""
+        current = self._read_manifest()
+        with self._state_guard:
+            observed = self._observed
+        if current.generation == observed.generation:
+            return current
+
+        with self._barrier.write(), self._file_barrier(shared=True):
+            current = self._read_manifest()
+            with self._state_guard:
+                observed = self._observed
+            if current.generation != observed.generation:
+                self.invalidate_callback(current)
+                with self._state_guard:
+                    self._observed = current
+        return current
+
+    def transition(
+        self,
+        revision: str,
+        purge_callback: PurgeCallback | None = None,
+    ) -> SourceGeneration:
+        """Atomically activate an immutable mirror revision.
+
+        The purge callback executes while every source reader is excluded. If it
+        raises, the manifest remains unchanged and a later caller can retry the
+        same transition without exposing a partially invalidated generation.
+        """
+        revision = self._validated_revision(revision)
+        if getattr(self._thread_local, "operation_depth", 0):
+            raise RuntimeError("Cannot transition the source inside source_operation().")
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+        with (
+            self._barrier.write(),
+            FileLock(str(self.transition_lock_path)),
+            self._file_barrier(shared=False),
+        ):
+            current = self._read_manifest()
+            if current.revision == revision:
+                with self._state_guard:
+                    self._observed = current
+                return current
+
+            candidate = SourceGeneration(
+                namespace=self.namespace,
+                generation=current.generation + 1,
+                revision=revision,
+                updated_at=time.time(),
+            )
+            callback = purge_callback or self.purge_callback
+            if callback is not None:
+                callback(current, candidate)
+            self._write_manifest(candidate)
+            self.invalidate_callback(candidate)
+            with self._state_guard:
+                self._observed = candidate
+            return candidate
+
+    def info(self) -> dict[str, str | int | float]:
+        return self.synchronize().to_dict()
+
+    def _read_manifest(self) -> SourceGeneration:
+        try:
+            raw = self.manifest_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return SourceGeneration(self.namespace, 0, "initial", 0.0)
+        except OSError as error:
+            raise CacheIntegrityError("Unable to read the source generation manifest.") from error
+        try:
+            value: Any = json.loads(raw)
+            if not isinstance(value, dict):
+                raise ValueError("manifest is not an object")
+            if value.get("manifest_version") != self.MANIFEST_VERSION:
+                raise ValueError("unsupported manifest version")
+            if value.get("namespace") != self.namespace:
+                raise ValueError("manifest namespace mismatch")
+            generation = value["generation"]
+            revision = value["revision"]
+            updated_at = value["updated_at"]
+            if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+                raise ValueError("invalid generation")
+            revision = self._validated_revision(revision)
+            if not isinstance(updated_at, int | float) or isinstance(updated_at, bool):
+                raise ValueError("invalid update time")
+            return SourceGeneration(
+                namespace=self.namespace,
+                generation=generation,
+                revision=revision,
+                updated_at=float(updated_at),
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise CacheIntegrityError("Invalid source generation manifest.") from error
+
+    def _write_manifest(self, state: SourceGeneration) -> None:
+        content = json.dumps(
+            {"manifest_version": self.MANIFEST_VERSION, **asdict(state)},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{self.manifest_path.name}.",
+            suffix=".tmp",
+            dir=self.directory,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_name, self.manifest_path)
+            directory_fd = os.open(self.directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary_name)
+
+    @contextmanager
+    def _file_barrier(self, *, shared: bool) -> Iterator[None]:
+        # The first reader must create the common lock location before it can
+        # observe a generation. Otherwise a concurrent first transition in a
+        # different worker could create and take the barrier while that reader
+        # proceeded without a file lock.
+        try:
+            self.directory.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            # Read-only clients can still validate absent translations and
+            # inspect process-local telemetry. Any operation that actually
+            # needs the shared disk cache or a transition will fail at its own
+            # write boundary; the in-process reader/writer barrier remains held.
+            yield
+            return
+        descriptor = os.open(self.barrier_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            if fcntl is not None:
+                operation = fcntl.LOCK_SH if shared else fcntl.LOCK_EX
+                fcntl.flock(descriptor, operation)
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+
+    @classmethod
+    def _validated_revision(cls, revision: object) -> str:
+        if not isinstance(revision, str):
+            raise TypeError("source revision must be a string.")
+        value = revision.strip()
+        if not value or len(value) > cls.MAX_REVISION_LENGTH:
+            raise ValueError(
+                f"source revision must contain 1 to {cls.MAX_REVISION_LENGTH} characters."
+            )
+        if any(ord(character) < 32 or ord(character) == 127 for character in value):
+            raise ValueError("source revision cannot contain control characters.")
+        return value

--- a/src/getbible/translation_cache.py
+++ b/src/getbible/translation_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import tempfile
 import threading
@@ -39,8 +40,45 @@ class TranslationSnapshot:
     stale: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class _CacheMetadata:
+    sha: str
+    checked_at: float
+    payload: str
+    books_sha: str
+    source_generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class _BookIndexEntry:
+    name: str
+    metadata: tuple[tuple[str, str], ...]
+
+
 class TranslationCache:
     """Coordinate in-memory and cross-process on-disk translation caching."""
+
+    VALIDATION_VERSION = 2
+    MAX_BOOKS = 256
+    MAX_CHAPTERS_PER_BOOK = 500
+    MAX_VERSES_PER_CHAPTER = 500
+    MAX_TOTAL_VERSES = 100_000
+    MAX_BOOK_NUMBER = 1_000
+    MAX_CHAPTER_NUMBER = 1_000
+    MAX_VERSE_NUMBER = 2_000
+    MAX_NAME_LENGTH = 4_096
+    MAX_TEXT_LENGTH = 1_048_576
+    MAX_METADATA_ITEMS = 10_000
+    MAX_METADATA_DEPTH = 8
+    MAX_METADATA_INTEGER = (1 << 63) - 1
+    BOOK_INDEX_METADATA = (
+        "translation",
+        "abbreviation",
+        "lang",
+        "language",
+        "direction",
+        "encoding",
+    )
 
     def __init__(
         self,
@@ -51,6 +89,7 @@ class TranslationCache:
         lock_timeout: float = 120.0,
         memory_limit: int | None = 4,
         refresh_jitter: float = 0.1,
+        require_checksums: bool = False,
     ) -> None:
         self.repository = repository
         self.refresh_seconds = max(0.0, refresh_seconds)
@@ -58,6 +97,9 @@ class TranslationCache:
         self.strict_freshness = strict_freshness
         self.lock_timeout = lock_timeout
         self.memory_limit = self._validated_limit("memory_limit", memory_limit)
+        if not isinstance(require_checksums, bool):
+            raise TypeError("require_checksums must be a boolean.")
+        self.require_checksums = require_checksums
         if not isinstance(refresh_jitter, (int, float)) or isinstance(
             refresh_jitter, bool
         ):
@@ -66,6 +108,7 @@ class TranslationCache:
             raise ValueError("refresh_jitter must be between 0 (inclusive) and 1.")
         self.refresh_jitter = float(refresh_jitter)
         self._memory: OrderedDict[str, TranslationSnapshot] = OrderedDict()
+        self._source_generation = 0
         self._locks = KeyedLockPool()
         self._guard = threading.RLock()
         self._stats = {
@@ -106,12 +149,12 @@ class TranslationCache:
                 if (
                     memory is not None
                     and metadata is not None
-                    and metadata[0] == memory.sha
+                    and metadata.sha == memory.sha
                 ):
                     disk = TranslationSnapshot(
                         memory.data,
                         memory.sha,
-                        metadata[1],
+                        metadata.checked_at,
                     )
                 else:
                     disk = self._read_disk(paths, metadata)
@@ -137,7 +180,7 @@ class TranslationCache:
                     refreshed = TranslationSnapshot(
                         disk.data, disk.sha, disk.checked_at, stale=True
                     )
-                except RepositoryError:
+                except (CacheIntegrityError, RepositoryError):
                     if disk is None or self.strict_freshness:
                         raise
                     LOGGER.warning(
@@ -159,6 +202,15 @@ class TranslationCache:
             else:
                 self._memory.pop(abbreviation, None)
 
+    def set_source_generation(self, generation: int) -> None:
+        """Expire retained state after an immutable source transition."""
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+            raise ValueError("source generation must be a non-negative integer.")
+        with self._guard:
+            if generation != self._source_generation:
+                self._source_generation = generation
+                self._memory.clear()
+
     def cache_info(self) -> dict[str, Any]:
         """Return a JSON-friendly snapshot of translation-cache state."""
         with self._guard:
@@ -176,6 +228,8 @@ class TranslationCache:
             "limit": self.memory_limit,
             "active_locks": self._locks.size,
             "translations": translations,
+            "require_checksums": self.require_checksums,
+            "validation_version": self.VALIDATION_VERSION,
             **stats,
         }
 
@@ -190,14 +244,28 @@ class TranslationCache:
             remote_sha = self.repository.fetch_text(f"{abbreviation}.sha").strip().lower()
         except RepositoryResourceNotFound:
             remote_sha = ""
+        if self.require_checksums and not remote_sha:
+            raise RepositoryResponseError(
+                f"Translation {abbreviation} does not publish a required checksum."
+            )
         if remote_sha and not self._valid_sha(remote_sha):
             raise RepositoryResponseError(
                 f"Invalid checksum published for translation {abbreviation}."
             )
 
+        books_raw = self.repository.fetch_bytes(f"{abbreviation}/books.json")
+        books_index = self._decode_books_index(books_raw, abbreviation)
+        books_sha = hashlib.sha1(books_raw, usedforsecurity=False).hexdigest()
+
         if disk is not None and remote_sha and disk.sha == remote_sha:
+            self._validate_books_match(disk.data, books_index, abbreviation)
             snapshot = TranslationSnapshot(disk.data, disk.sha, now)
-            self._write_metadata(paths["metadata"], snapshot)
+            self._write_metadata(
+                paths["metadata"],
+                snapshot,
+                payload=f"{disk.sha}.json",
+                books_sha=books_sha,
+            )
             return snapshot
 
         raw = self.repository.fetch_bytes(f"{abbreviation}.json")
@@ -209,34 +277,70 @@ class TranslationCache:
                 f"expected {remote_sha}, received {actual_sha}."
             )
 
-        data = self._decode_translation(raw, abbreviation)
+        data = self._decode_translation(raw, abbreviation, books_index)
         snapshot = TranslationSnapshot(data, actual_sha, now)
-        self._write_atomic(paths["translation"], raw)
-        self._write_metadata(paths["metadata"], snapshot)
+        paths["objects"].mkdir(parents=True, exist_ok=True)
+        payload = paths["objects"] / f"{actual_sha}.json"
+        self._write_content_addressed(payload, raw, actual_sha)
+        self._write_metadata(
+            paths["metadata"],
+            snapshot,
+            payload=payload.name,
+            books_sha=books_sha,
+        )
         return snapshot
 
-    def _read_metadata(self, paths: dict[str, Path]) -> tuple[str, float] | None:
+    def _read_metadata(self, paths: dict[str, Path]) -> _CacheMetadata | None:
         try:
             metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
             expected_sha = metadata["sha"]
             checked_at = float(metadata["checked_at"])
+            payload = metadata["payload"]
+            books_sha = metadata["books_sha"]
+            source_generation = metadata["source_generation"]
         except (FileNotFoundError, OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
             return None
-        if not self._valid_sha(expected_sha):
+        if (
+            metadata.get("validation_version") != self.VALIDATION_VERSION
+            or metadata.get("source") != self.repository.repo_path
+            or metadata.get("version") != self.repository.version
+            or not self._valid_sha(expected_sha)
+            or not self._valid_sha(books_sha)
+            or not math.isfinite(checked_at)
+            or checked_at < 0
+            or payload != f"{expected_sha}.json"
+            or not isinstance(source_generation, int)
+            or isinstance(source_generation, bool)
+            or source_generation < 0
+        ):
             return None
-        return expected_sha, checked_at
+        return _CacheMetadata(
+            expected_sha,
+            checked_at,
+            payload,
+            books_sha,
+            source_generation,
+        )
 
     def _read_disk(
         self,
         paths: dict[str, Path],
-        metadata: tuple[str, float] | None = None,
+        metadata: _CacheMetadata | None = None,
     ) -> TranslationSnapshot | None:
         metadata = metadata or self._read_metadata(paths)
         if metadata is None:
             return None
-        expected_sha, checked_at = metadata
+        expected_sha = metadata.sha
+        with self._guard:
+            source_generation = self._source_generation
+        checked_at = (
+            metadata.checked_at
+            if metadata.source_generation == source_generation
+            else 0.0
+        )
+        payload = paths["objects"] / metadata.payload
         try:
-            raw = paths["translation"].read_bytes()
+            raw = payload.read_bytes()
         except OSError:
             return None
 
@@ -245,14 +349,20 @@ class TranslationCache:
             LOGGER.warning("Ignoring a corrupt Librarian translation cache entry.")
             return None
         try:
-            data = self._decode_translation(raw, paths["translation"].stem)
+            abbreviation = paths["metadata"].name.removesuffix(".metadata.json")
+            data = self._decode_translation(raw, abbreviation)
         except (CacheIntegrityError, RepositoryResponseError):
             LOGGER.warning("Ignoring an invalid Librarian translation cache entry.")
             return None
         return TranslationSnapshot(data, actual_sha, checked_at)
 
-    @staticmethod
-    def _decode_translation(raw: bytes, abbreviation: str) -> dict[str, Any]:
+    @classmethod
+    def _decode_translation(
+        cls,
+        raw: bytes,
+        abbreviation: str,
+        books_index: dict[int, _BookIndexEntry] | None = None,
+    ) -> dict[str, Any]:
         try:
             data = json.loads(raw)
         except (UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -268,7 +378,360 @@ class TranslationCache:
                 f"Translation payload {data.get('abbreviation')!r} does not match "
                 f"requested abbreviation {abbreviation!r}."
             )
+        cls._validate_metadata(data, abbreviation)
+        books = data["books"]
+        if not books or len(books) > cls.MAX_BOOKS:
+            raise CacheIntegrityError(
+                f"Translation {abbreviation} must contain 1 to {cls.MAX_BOOKS} books."
+            )
+
+        seen_books: set[int] = set()
+        total_verses = 0
+        corpus_books: dict[int, _BookIndexEntry] = {}
+        for book in books:
+            if not isinstance(book, dict):
+                raise CacheIntegrityError("Translation contains a non-object book entry.")
+            book_nr = cls._required_integer(
+                book, "nr", 1, cls.MAX_BOOK_NUMBER, "book number"
+            )
+            book_name = cls._required_string(book, "name", cls.MAX_NAME_LENGTH, "book name")
+            cls._validate_supplemental_fields(
+                book,
+                {"nr", "name", "chapters"},
+                "book",
+            )
+            if book_nr in seen_books:
+                raise CacheIntegrityError(f"Translation contains duplicate book {book_nr}.")
+            seen_books.add(book_nr)
+            corpus_books[book_nr] = cls._book_index_entry(book_name, data)
+            chapters = book.get("chapters")
+            if not isinstance(chapters, list) or not chapters:
+                raise CacheIntegrityError(f"Book {book_nr} does not contain chapters.")
+            if len(chapters) > cls.MAX_CHAPTERS_PER_BOOK:
+                raise CacheIntegrityError(f"Book {book_nr} exceeds the chapter ceiling.")
+            seen_chapters: set[int] = set()
+            for chapter in chapters:
+                if not isinstance(chapter, dict):
+                    raise CacheIntegrityError(f"Book {book_nr} contains an invalid chapter.")
+                chapter_nr = cls._required_integer(
+                    chapter, "chapter", 1, cls.MAX_CHAPTER_NUMBER, "chapter number"
+                )
+                cls._required_string(
+                    chapter, "name", cls.MAX_NAME_LENGTH, "chapter name"
+                )
+                cls._validate_supplemental_fields(
+                    chapter,
+                    {"chapter", "name", "verses"},
+                    "chapter",
+                )
+                if chapter_nr in seen_chapters:
+                    raise CacheIntegrityError(
+                        f"Book {book_nr} contains duplicate chapter {chapter_nr}."
+                    )
+                seen_chapters.add(chapter_nr)
+                verses = chapter.get("verses")
+                if not isinstance(verses, list) or not verses:
+                    raise CacheIntegrityError(
+                        f"Book {book_nr} chapter {chapter_nr} does not contain verses."
+                    )
+                if len(verses) > cls.MAX_VERSES_PER_CHAPTER:
+                    raise CacheIntegrityError(
+                        f"Book {book_nr} chapter {chapter_nr} exceeds the verse ceiling."
+                    )
+                seen_verses: set[int] = set()
+                for verse in verses:
+                    if not isinstance(verse, dict):
+                        raise CacheIntegrityError(
+                            f"Book {book_nr} chapter {chapter_nr} contains an invalid verse."
+                        )
+                    verse_chapter = cls._required_integer(
+                        verse, "chapter", 1, cls.MAX_CHAPTER_NUMBER, "verse chapter"
+                    )
+                    verse_nr = cls._required_integer(
+                        verse, "verse", 1, cls.MAX_VERSE_NUMBER, "verse number"
+                    )
+                    cls._required_string(verse, "name", cls.MAX_NAME_LENGTH, "verse name")
+                    cls._required_string(
+                        verse,
+                        "text",
+                        cls.MAX_TEXT_LENGTH,
+                        "verse text",
+                        allow_empty=True,
+                    )
+                    cls._validate_supplemental_fields(
+                        verse,
+                        {"chapter", "verse", "name", "text"},
+                        "verse",
+                    )
+                    if verse_chapter != chapter_nr:
+                        raise CacheIntegrityError(
+                            f"Verse {book_nr}:{chapter_nr}:{verse_nr} has a mismatched chapter."
+                        )
+                    if verse_nr in seen_verses:
+                        raise CacheIntegrityError(
+                            f"Book {book_nr} chapter {chapter_nr} contains duplicate verse "
+                            f"{verse_nr}."
+                        )
+                    seen_verses.add(verse_nr)
+                    total_verses += 1
+                    if total_verses > cls.MAX_TOTAL_VERSES:
+                        raise CacheIntegrityError("Translation exceeds the total verse ceiling.")
+
+        if books_index is not None and corpus_books != books_index:
+            raise CacheIntegrityError(
+                f"Translation {abbreviation} does not match its independent books index."
+            )
         return data
+
+    @classmethod
+    def _decode_books_index(
+        cls,
+        raw: bytes,
+        abbreviation: str,
+    ) -> dict[int, _BookIndexEntry]:
+        try:
+            data = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RepositoryResponseError(
+                f"Books index for {abbreviation} is not valid JSON."
+            ) from error
+        if not isinstance(data, dict) or not data or len(data) > cls.MAX_BOOKS:
+            raise CacheIntegrityError(
+                f"Books index for {abbreviation} does not contain a bounded object."
+            )
+        result: dict[int, _BookIndexEntry] = {}
+        for key, book in data.items():
+            if not isinstance(key, str) or not key.isascii() or not key.isdigit():
+                raise CacheIntegrityError("Books index contains an invalid book key.")
+            if not isinstance(book, dict):
+                raise CacheIntegrityError("Books index contains a non-object book.")
+            nr = cls._required_integer(book, "nr", 1, cls.MAX_BOOK_NUMBER, "book number")
+            name = cls._required_string(book, "name", cls.MAX_NAME_LENGTH, "book name")
+            if int(key) != nr or nr in result:
+                raise CacheIntegrityError("Books index contains inconsistent book numbers.")
+            if book.get("abbreviation") != abbreviation:
+                raise CacheIntegrityError(
+                    f"Books index payload does not match abbreviation {abbreviation}."
+                )
+            cls._validate_supplemental_fields(
+                book,
+                {"nr", "name", *cls.BOOK_INDEX_METADATA},
+                "books index entry",
+            )
+            result[nr] = cls._book_index_entry(name, book)
+        return result
+
+    @classmethod
+    def validate_chapter_payload(
+        cls,
+        data: object,
+        abbreviation: str,
+        book_nr: int,
+        chapter_nr: int,
+    ) -> None:
+        """Validate a lightweight chapter response before retaining it."""
+        if not isinstance(data, dict):
+            raise CacheIntegrityError(
+                f"Invalid chapter structure for {abbreviation} {book_nr}:{chapter_nr}."
+            )
+        if data.get("abbreviation") != abbreviation:
+            raise CacheIntegrityError("Chapter payload contains a mismatched abbreviation.")
+        if cls._required_integer(
+            data, "book_nr", 1, cls.MAX_BOOK_NUMBER, "book number"
+        ) != book_nr:
+            raise CacheIntegrityError("Chapter payload contains a mismatched book number.")
+        if cls._required_integer(
+            data, "chapter", 1, cls.MAX_CHAPTER_NUMBER, "chapter number"
+        ) != chapter_nr:
+            raise CacheIntegrityError("Chapter payload contains a mismatched chapter number.")
+        cls._required_string(data, "book_name", cls.MAX_NAME_LENGTH, "book name")
+        cls._required_string(data, "name", cls.MAX_NAME_LENGTH, "chapter name")
+        cls._validate_supplemental_fields(
+            data,
+            {
+                "book_nr",
+                "book_name",
+                "chapter",
+                "name",
+                "verses",
+                *cls.BOOK_INDEX_METADATA,
+            },
+            "chapter payload",
+        )
+        verses = data.get("verses")
+        if (
+            not isinstance(verses, list)
+            or not verses
+            or len(verses) > cls.MAX_VERSES_PER_CHAPTER
+        ):
+            raise CacheIntegrityError("Chapter payload contains an invalid verse array.")
+        seen: set[int] = set()
+        for verse in verses:
+            if not isinstance(verse, dict):
+                raise CacheIntegrityError("Chapter payload contains an invalid verse.")
+            if cls._required_integer(
+                verse, "chapter", 1, cls.MAX_CHAPTER_NUMBER, "verse chapter"
+            ) != chapter_nr:
+                raise CacheIntegrityError("Chapter verse contains a mismatched chapter number.")
+            verse_nr = cls._required_integer(
+                verse, "verse", 1, cls.MAX_VERSE_NUMBER, "verse number"
+            )
+            cls._required_string(verse, "name", cls.MAX_NAME_LENGTH, "verse name")
+            cls._required_string(
+                verse,
+                "text",
+                cls.MAX_TEXT_LENGTH,
+                "verse text",
+                allow_empty=True,
+            )
+            cls._validate_supplemental_fields(
+                verse,
+                {"chapter", "verse", "name", "text"},
+                "chapter verse",
+            )
+            if verse_nr in seen:
+                raise CacheIntegrityError("Chapter payload contains a duplicate verse number.")
+            seen.add(verse_nr)
+
+    @classmethod
+    def _validate_books_match(
+        cls,
+        data: dict[str, Any],
+        books_index: dict[int, _BookIndexEntry],
+        abbreviation: str,
+    ) -> None:
+        try:
+            corpus_books = {
+                int(book["nr"]): cls._book_index_entry(str(book["name"]), data)
+                for book in data["books"]
+            }
+        except (KeyError, TypeError, ValueError) as error:
+            raise CacheIntegrityError(
+                f"Translation {abbreviation} contains invalid cached book data."
+            ) from error
+        if corpus_books != books_index:
+            raise CacheIntegrityError(
+                f"Translation {abbreviation} does not match its independent books index."
+            )
+
+    @classmethod
+    def _book_index_entry(
+        cls,
+        name: str,
+        source: dict[str, Any],
+    ) -> _BookIndexEntry:
+        metadata: list[tuple[str, str]] = []
+        for field in cls.BOOK_INDEX_METADATA:
+            value = source.get(field)
+            if not isinstance(value, str) or not value or len(value) > cls.MAX_NAME_LENGTH:
+                raise CacheIntegrityError(
+                    f"Books index contains an invalid {field!r} field."
+                )
+            metadata.append((field, value))
+        return _BookIndexEntry(name, tuple(metadata))
+
+    @classmethod
+    def _validate_metadata(cls, data: dict[str, Any], abbreviation: str) -> None:
+        if len(data) > cls.MAX_METADATA_ITEMS:
+            raise CacheIntegrityError(
+                f"Translation {abbreviation} contains too many metadata fields."
+            )
+        for key, value in data.items():
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise CacheIntegrityError(
+                    f"Translation {abbreviation} contains an invalid metadata key."
+                )
+            if key == "books":
+                continue
+            cls._validate_metadata_value(value, 0, f"metadata field {key!r}")
+        cls._required_string(
+            data, "translation", cls.MAX_NAME_LENGTH, "translation name"
+        )
+        cls._required_string(
+            data, "abbreviation", 30, "translation abbreviation"
+        )
+
+    @classmethod
+    def _validate_supplemental_fields(
+        cls,
+        value: dict[str, Any],
+        structural_fields: set[str],
+        label: str,
+    ) -> None:
+        if len(value) > cls.MAX_METADATA_ITEMS:
+            raise CacheIntegrityError(f"Translation {label} contains too many fields.")
+        for key, item in value.items():
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise CacheIntegrityError(f"Translation {label} contains an invalid field name.")
+            if key not in structural_fields:
+                cls._validate_metadata_value(item, 0, f"{label} field {key!r}")
+
+    @classmethod
+    def _validate_metadata_value(cls, value: Any, depth: int, label: str) -> None:
+        if depth > cls.MAX_METADATA_DEPTH:
+            raise CacheIntegrityError(f"Translation {label} exceeds the nesting ceiling.")
+        if isinstance(value, str):
+            if len(value) > cls.MAX_TEXT_LENGTH:
+                raise CacheIntegrityError(f"Translation {label} exceeds the text ceiling.")
+            return
+        if value is None or isinstance(value, bool):
+            return
+        if isinstance(value, int):
+            if abs(value) > cls.MAX_METADATA_INTEGER:
+                raise CacheIntegrityError(f"Translation {label} exceeds the numeric ceiling.")
+            return
+        if isinstance(value, float):
+            if not math.isfinite(value) or abs(value) > cls.MAX_METADATA_INTEGER:
+                raise CacheIntegrityError(f"Translation {label} exceeds the numeric ceiling.")
+            return
+        if isinstance(value, dict):
+            if len(value) > cls.MAX_METADATA_ITEMS:
+                raise CacheIntegrityError(f"Translation {label} contains too many entries.")
+            for key, item in value.items():
+                if not isinstance(key, str) or not key or len(key) > 128:
+                    raise CacheIntegrityError(f"Translation {label} has an invalid key.")
+                cls._validate_metadata_value(item, depth + 1, label)
+            return
+        if isinstance(value, list):
+            if len(value) > cls.MAX_METADATA_ITEMS:
+                raise CacheIntegrityError(f"Translation {label} contains too many entries.")
+            for item in value:
+                cls._validate_metadata_value(item, depth + 1, label)
+            return
+        raise CacheIntegrityError(f"Translation {label} contains an unsupported value.")
+
+    @staticmethod
+    def _required_integer(
+        value: dict[str, Any],
+        key: str,
+        minimum: int,
+        maximum: int,
+        label: str,
+    ) -> int:
+        result = value.get(key)
+        if not isinstance(result, int) or isinstance(result, bool):
+            raise CacheIntegrityError(f"Translation contains an invalid {label}.")
+        if not minimum <= result <= maximum:
+            raise CacheIntegrityError(
+                f"Translation {label} must be between {minimum} and {maximum}."
+            )
+        return result
+
+    @staticmethod
+    def _required_string(
+        value: dict[str, Any],
+        key: str,
+        maximum: int,
+        label: str,
+        *,
+        allow_empty: bool = False,
+    ) -> str:
+        result = value.get(key)
+        if not isinstance(result, str):
+            raise CacheIntegrityError(f"Translation contains an invalid {label}.")
+        if (not allow_empty and not result.strip()) or len(result) > maximum:
+            raise CacheIntegrityError(f"Translation contains an invalid {label}.")
+        return result
 
     def _paths(self, abbreviation: str) -> dict[str, Path]:
         namespace = hashlib.sha256(
@@ -277,7 +740,7 @@ class TranslationCache:
         directory = self.cache_dir / namespace / self.repository.version
         return {
             "directory": directory,
-            "translation": directory / f"{abbreviation}.json",
+            "objects": directory / "objects",
             "metadata": directory / f"{abbreviation}.metadata.json",
             "lock": directory / f"{abbreviation}.lock",
         }
@@ -293,17 +756,48 @@ class TranslationCache:
         base = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
         return base / "getbible"
 
-    def _write_metadata(self, path: Path, snapshot: TranslationSnapshot) -> None:
+    def _write_metadata(
+        self,
+        path: Path,
+        snapshot: TranslationSnapshot,
+        *,
+        payload: str | None = None,
+        books_sha: str | None = None,
+    ) -> None:
+        existing = self._read_metadata({"metadata": path})
+        payload = payload or (existing.payload if existing is not None else f"{snapshot.sha}.json")
+        books_sha = books_sha or (existing.books_sha if existing is not None else "")
+        if not self._valid_sha(books_sha):
+            raise CacheIntegrityError(
+                "Cannot commit translation metadata without a books checksum."
+            )
         metadata = json.dumps(
             {
+                "validation_version": self.VALIDATION_VERSION,
                 "sha": snapshot.sha,
                 "checked_at": snapshot.checked_at,
+                "payload": payload,
+                "books_sha": books_sha,
+                "source_generation": self._source_generation,
                 "source": self.repository.repo_path,
                 "version": self.repository.version,
             },
             sort_keys=True,
         ).encode("utf-8")
         self._write_atomic(path, metadata)
+
+    @staticmethod
+    def _write_content_addressed(path: Path, content: bytes, expected_sha: str) -> None:
+        if path.exists():
+            try:
+                existing_sha = hashlib.sha1(
+                    path.read_bytes(), usedforsecurity=False
+                ).hexdigest()
+            except OSError:
+                existing_sha = ""
+            if existing_sha == expected_sha:
+                return
+        TranslationCache._write_atomic(path, content)
 
     @staticmethod
     def _write_atomic(path: Path, content: bytes) -> None:
@@ -316,6 +810,11 @@ class TranslationCache:
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(temporary_name, path)
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
         finally:
             with suppress(FileNotFoundError):
                 os.unlink(temporary_name)

--- a/tests/test_release_hardening.py
+++ b/tests/test_release_hardening.py
@@ -1,0 +1,274 @@
+import hashlib
+import json
+import shutil
+import tempfile
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from getbible import (
+    CacheIntegrityError,
+    GetBible,
+    RepositoryResponseError,
+    SearchBible,
+    SearchDeadlineExceeded,
+    SearchLimitError,
+    SearchLimits,
+    SearchValidationError,
+    TranslationNotFoundError,
+)
+
+FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "repository"
+
+
+class ReleaseHardeningTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.repository = self.root / "repository"
+        shutil.copytree(FIXTURE_REPOSITORY, self.repository)
+        self.cache = self.root / "cache"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _bible(self, **kwargs: object) -> GetBible:
+        bible = GetBible(
+            repo_path=self.repository,
+            cache_dir=self.cache,
+            **kwargs,
+        )
+        self.addCleanup(bible.close)
+        return bible
+
+    def _publish_translation_sha(self) -> str:
+        translation = self.repository / "v2" / "test.json"
+        checksum = hashlib.sha1(translation.read_bytes()).hexdigest()
+        (translation.parent / "test.sha").write_text(checksum, encoding="utf-8")
+        return checksum
+
+    def test_missing_search_and_warm_never_enter_translation_cache(self) -> None:
+        bible = self._bible()
+        with patch.object(bible._translation_cache, "load") as load:
+            for operation in (
+                lambda: bible.search("faith", "missing"),
+                lambda: bible.warm_translation("missing"),
+            ):
+                with self.assertRaises(TranslationNotFoundError):
+                    operation()
+        load.assert_not_called()
+        self.assertEqual(bible.cache_info()["negative_translations"]["size"], 1)
+
+    def test_invalid_nested_refresh_preserves_last_known_good_corpus(self) -> None:
+        self._publish_translation_sha()
+        bible = self._bible(cache_ttl=timedelta(seconds=0))
+        first = bible.search("faith", "test")
+
+        translation_path = self.repository / "v2" / "test.json"
+        invalid = json.loads(translation_path.read_text(encoding="utf-8"))
+        invalid["books"][0]["chapters"][0]["verses"][0]["chapter"] = 999
+        translation_path.write_text(json.dumps(invalid), encoding="utf-8")
+        self._publish_translation_sha()
+
+        second = bible.search("faith", "test")
+        self.assertEqual(second["query"]["sha"], first["query"]["sha"])
+        self.assertTrue(second["query"]["cache"]["stale"])
+
+    def test_books_index_mismatch_is_rejected_before_cache_commit(self) -> None:
+        books_path = self.repository / "v2" / "test" / "books.json"
+        books = json.loads(books_path.read_text(encoding="utf-8"))
+        books["1"]["name"] = "Not Genesis"
+        books_path.write_text(json.dumps(books), encoding="utf-8")
+        bible = self._bible()
+
+        with self.assertRaises(CacheIntegrityError):
+            bible.search("faith", "test")
+        metadata = tuple(self.cache.rglob("test.metadata.json"))
+        self.assertEqual(metadata, ())
+
+    def test_validated_payload_is_content_addressed_and_versioned(self) -> None:
+        sha = self._publish_translation_sha()
+        bible = self._bible(require_checksums=True)
+        bible.search("faith", "test")
+
+        metadata_path = next(self.cache.rglob("test.metadata.json"))
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        self.assertEqual(metadata["validation_version"], 2)
+        self.assertEqual(metadata["sha"], sha)
+        self.assertEqual(metadata["payload"], f"{sha}.json")
+        self.assertEqual(metadata["source_generation"], 0)
+        self.assertTrue((metadata_path.parent / "objects" / f"{sha}.json").is_file())
+
+    def test_required_full_and_chapter_checksums_fail_closed(self) -> None:
+        bible = self._bible(require_checksums=True)
+        with self.assertRaisesRegex(RepositoryResponseError, "required checksum"):
+            bible.search("faith", "test")
+        with self.assertRaisesRegex(RepositoryResponseError, "required checksum"):
+            bible.select("1 1:1", "test")
+
+        chapter = self.repository / "v2" / "test" / "1" / "1.json"
+        chapter.with_suffix(".sha").write_text("0" * 40, encoding="utf-8")
+        optional = self._bible(require_checksums=False)
+        with self.assertRaises(CacheIntegrityError):
+            optional.select("1 1:1", "test")
+
+    def test_select_and_search_results_do_not_mutate_cached_data(self) -> None:
+        bible = self._bible()
+        selected = bible.select("1 1:1", "test")
+        selected["test_1_1"]["translation"] = "mutated"
+        selected["test_1_1"]["verses"][0]["text"] = "mutated"
+        selected_again = bible.select("1 1:1", "test")["test_1_1"]
+        self.assertEqual(selected_again["translation"], "Librarian Test Translation")
+        self.assertNotEqual(selected_again["verses"][0]["text"], "mutated")
+
+        searched = bible.search("faith", "test")
+        searched["query"]["translation"]["translation"] = "mutated"
+        searched["results"]["test_1_1"]["verses"][0]["text"] = "mutated"
+        searched_again = bible.search("faith", "test")
+        self.assertEqual(
+            searched_again["query"]["translation"]["translation"],
+            "Librarian Test Translation",
+        )
+        self.assertNotEqual(
+            searched_again["results"]["test_1_1"]["verses"][0]["text"],
+            "mutated",
+        )
+
+    def test_expensive_classification_and_substring_minimum_are_pre_execution(self) -> None:
+        self.assertTrue(SearchBible(match="substring").expensive)
+        self.assertFalse(SearchBible().expensive)
+        bible = self._bible()
+        with (
+            patch.object(bible._translation_cache, "load") as load,
+            self.assertRaises(SearchValidationError),
+        ):
+            bible.search("a", "test", SearchBible(match="substring"))
+        load.assert_not_called()
+
+    def test_work_response_and_deadline_budgets_are_enforced(self) -> None:
+        work_limited = self._bible(search_limits=SearchLimits(max_work_units=1))
+        with (
+            patch("getbible.search.TranslationCorpus.index") as build_index,
+            self.assertRaises(SearchLimitError),
+        ):
+            work_limited.search("faith", "test")
+        build_index.assert_not_called()
+
+        response_limited = self._bible(
+            search_limits=SearchLimits(max_response_bytes=100)
+        )
+        with self.assertRaises(SearchLimitError):
+            response_limited.search("faith", "test")
+
+        deadline_limited = self._bible(
+            search_limits=SearchLimits(
+                deadline_seconds=0.001,
+                deadline_check_interval=1,
+            )
+        )
+        with (
+            patch(
+                "getbible.search.SearchBudget.checkpoint",
+                side_effect=SearchDeadlineExceeded("deadline"),
+            ),
+            self.assertRaises(SearchDeadlineExceeded),
+        ):
+            deadline_limited.search("faith", "test")
+
+    def test_generation_transition_invalidates_other_workers(self) -> None:
+        first = self._bible()
+        second = self._bible()
+        first.search("faith", "test")
+        second.search("faith", "test")
+        self.assertEqual(second.cache_info()["search_corpora"]["size"], 1)
+
+        calls: list[tuple[int, int]] = []
+        transitioned = first.transition_source(
+            "mirror-2026-07-20",
+            lambda old, new: calls.append((old.generation, new.generation)),
+        )
+        self.assertEqual(calls, [(0, 1)])
+        self.assertEqual(transitioned["generation"], 1)
+
+        with second.source_operation() as generation:
+            self.assertEqual(generation.generation, 1)
+            self.assertTrue(generation.cache_namespace.endswith(":g1"))
+        self.assertEqual(second.cache_info()["search_corpora"]["size"], 0)
+        self.assertEqual(second.cache_info()["negative_translations"]["size"], 0)
+
+        translation_path = self.repository / "v2" / "test.json"
+        translation = json.loads(translation_path.read_text(encoding="utf-8"))
+        translation["books"][0]["chapters"][0]["verses"][0]["text"] = (
+            "Beacon comes by hearing."
+        )
+        translation_path.write_text(json.dumps(translation), encoding="utf-8")
+        self.assertEqual(second.search("beacon", "test")["query"]["total"], 1)
+        metadata_path = next(self.cache.rglob("test.metadata.json"))
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        self.assertEqual(metadata["source_generation"], 1)
+
+    def test_transition_waits_for_a_reader_that_started_before_first_manifest(self) -> None:
+        first = self._bible()
+        second = self._bible()
+        entered = threading.Event()
+        release = threading.Event()
+        purged = threading.Event()
+
+        def read_source() -> None:
+            with first.source_operation():
+                entered.set()
+                self.assertTrue(release.wait(2))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            reader = executor.submit(read_source)
+            self.assertTrue(entered.wait(2))
+            transition = executor.submit(
+                second.transition_source,
+                "after-reader",
+                lambda *_: purged.set(),
+            )
+            self.assertFalse(purged.wait(0.05))
+            release.set()
+            reader.result(timeout=2)
+            state = transition.result(timeout=2)
+
+        self.assertTrue(purged.is_set())
+        self.assertEqual(state["generation"], 1)
+
+    def test_failed_or_duplicate_generation_purge_cannot_partially_commit(self) -> None:
+        first = self._bible()
+        second = self._bible()
+
+        def fail(*_: object) -> None:
+            raise RuntimeError("purge failed")
+
+        with self.assertRaisesRegex(RuntimeError, "purge failed"):
+            first.transition_source("broken", fail)
+        self.assertEqual(first.cache_info()["source"]["generation"], 0)
+
+        calls = 0
+        guard = threading.Lock()
+
+        def purge(*_: object) -> None:
+            nonlocal calls
+            with guard:
+                calls += 1
+            time.sleep(0.01)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            states = list(
+                executor.map(
+                    lambda bible: bible.transition_source("stable", purge),
+                    (first, second),
+                )
+            )
+        self.assertEqual(calls, 1)
+        self.assertEqual({state["generation"] for state in states}, {1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_sources.py
+++ b/tests/test_repository_sources.py
@@ -43,6 +43,7 @@ class TestRepositorySources(unittest.TestCase):
         self.remote = GetBible(
             repo_path=self.repository_url,
             cache_dir=cache_root / "remote",
+            require_checksums=False,
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
## Summary

Prepare Librarian 1.2.0 for the next stable release by completing the production hardening gate across search, source caching, returned-object ownership, deployment limits, and immutable publication.

## Changes

- validate missing Search and warm-up translations through the bounded negative TTL/LRU cache before abbreviation-specific translation cache paths and locks
- validate complete full-translation, books-index, chapter, and verse structures with finite numeric/nesting/size ceilings; require production checksums; enforce chapter SHAs; preserve last-known-good corpora; commit content-addressed payloads through versioned atomic metadata
- add deterministic `SearchLimits` work/output/filter/deadline budgets, minimum substring lengths, cooperative checkpoints, and pre-execution `SearchBible.expensive` classification
- deep-copy every returned Query/Search verse and metadata boundary
- add atomic source-generation manifests, reader/transition barriers, worker and disk-cache invalidation, stable response-cache namespaces, serialized purge callbacks, and external `source_operation()` transactions
- replace mutable release Actions and static PyPI credentials with a frozen-master, Python 3.10–3.14, build-once, attested trusted-publishing workflow
- add packaged Query/Search systemd cgroup drop-ins and update the release, caching, hardening, search, integration, and operations documentation

## Validation

- `python -m unittest discover -s tests -v`: **107 passed**, 12 opt-in live tests skipped
- `ruff check src tests benchmarks scripts examples`: passed
- `bandit -q -r src/getbible -x src/getbible/data`: passed
- `python -m pip_audit`: no known vulnerabilities
- sdist and wheel build, `twine check`, packaged systemd drop-in inspection, and isolated-wheel imports: passed
- `GETBIBLE_RUN_LIVE_TESTS=1 python -m unittest tests.test_getbible tests.test_live_search -v`: **12 passed** against the production API

## Release readiness

The package remains at 1.2.0 with the changelog marked Unreleased. After integration review, set the release date, merge through `staging` to the frozen `master` commit, confirm CI/live integration, and dispatch the trusted-publishing Release workflow.