### PR TITLE
Improve release gate testing guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
+      - name: Validate local release gate entry point
+        run: bash -n scripts/run_release_gate.sh
+
       - name: Lint
         run: |
           set +e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable project changes are documented here.
 - Deterministic `SearchLimits`, response-volume accounting, substring minimums, cooperative deadlines, and pre-execution `SearchBible.expensive` classification.
 - Atomic source-generation manifests, reader/transition barriers, stable external cache namespaces, failure-serialized purge callbacks, and worker cache invalidation.
 - Maintained Query and Search systemd resource-limit drop-ins.
+- A one-command local release gate that bootstraps the development toolchain,
+  mirrors CI checks, and can append the opt-in live API integration suite.
 
 ### Changed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,5 @@ recursive-include benchmarks *.py
 recursive-include deploy *.conf
 recursive-include docs *.md
 recursive-include examples *.py
-recursive-include scripts *.py
+recursive-include scripts *.py *.sh
 recursive-include tests *.py *.json

--- a/README.md
+++ b/README.md
@@ -191,20 +191,20 @@ python -m venv .venv
 ## Development
 
 ```bash
-python -m venv .venv
-.venv/bin/python -m pip install -r requirements-dev.txt
-.venv/bin/python -m unittest discover -s tests -v
-.venv/bin/ruff check src tests benchmarks scripts examples
-.venv/bin/python -m build
-.venv/bin/python -m twine check dist/*
+./scripts/run_release_gate.sh
 ```
 
-Live API tests are intentionally opt-in:
+This creates or reuses `.venv`, installs every development tool, and runs the
+local deterministic release gate. GitHub's manually dispatchable **CI**
+workflow is the authoritative Python 3.10–3.14 check. Live API tests remain
+separate and intentionally opt-in:
 
 ```bash
-GETBIBLE_RUN_LIVE_TESTS=1 .venv/bin/python -m unittest \
-  tests.test_getbible tests.test_live_search -v
+./scripts/run_release_gate.sh --live
 ```
+
+See the [security and reliability release gate](docs/RELEASE_GATE.md) for
+manual commands, expected diagnostics, and GitHub workflow instructions.
 
 ## License
 

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -2,20 +2,81 @@
 
 A staging commit is releasable only when every item below passes without suppressing or deleting an existing assertion.
 
-## Automated gate
+## Choose the right gate
+
+GitHub Actions is the authoritative release gate because it validates every
+supported Python version in a clean runner:
+
+1. Open **Actions** in GitHub.
+2. Select **CI** and choose **Run workflow** for the branch or commit under
+   review. CI runs deterministic tests on Python 3.10 through 3.14, followed by
+   lint, security, dependency, package, and isolated-wheel checks.
+3. Select **Live API Integration** and choose **Run workflow** before a release.
+   This separate job checks the public API without making pull-request CI
+   dependent on an external service. It also runs on a weekly schedule.
+
+Both workflows support manual dispatch. A pull request to `staging` or `master`
+also starts CI automatically.
+
+## One-command local gate
+
+From the repository root, run:
 
 ```bash
-python -m pip install -r requirements-dev.txt
-python -m compileall -q src tests
-python -m unittest discover -s tests -v
-ruff check src tests benchmarks scripts examples
-bandit -q -r src/getbible -x src/getbible/data
-python -m pip_audit
-python -m build
-python -m twine check dist/*
+./scripts/run_release_gate.sh
 ```
 
-CI runs deterministic tests on Python 3.10 through 3.14, then installs and imports the built wheel in an isolated environment. Live API integration remains a separate opt-in workflow so the deterministic gate cannot be made flaky by an external service.
+The script creates or reuses `.venv`, installs `requirements-dev.txt`, and runs
+the same categories of deterministic, quality, dependency, build, and isolated
+wheel checks as CI on the current Python interpreter. It deliberately uses the
+tools inside `.venv`; global or Snap installations of Ruff, Bandit, Build,
+Twine, or pip-audit are neither needed nor used.
+
+To append the opt-in live API checks:
+
+```bash
+./scripts/run_release_gate.sh --live
+```
+
+Set `PYTHON=python3.14` to choose the interpreter when creating `.venv`, or set
+`VENV_DIR` to use a different virtual-environment directory. Delete or rename
+an existing environment first if its Python interpreter needs to change.
+
+The local gate validates one Python interpreter. A green GitHub **CI** run is
+still required for the complete Python 3.10–3.14 matrix.
+
+## Manual local commands
+
+If an individual check needs investigation, the equivalent commands are:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+.venv/bin/python -m compileall -q src tests
+.venv/bin/python -m unittest discover -s tests -v
+.venv/bin/ruff check src tests benchmarks scripts examples
+.venv/bin/bandit -q -r src/getbible -x src/getbible/data
+.venv/bin/python -m pip_audit --cache-dir .cache/pip-audit
+.venv/bin/python -m build
+.venv/bin/python -m twine check dist/*
+```
+
+Installing only the runtime package with `.venv/bin/python -m pip install -e .`
+does **not** install the release tools. Use `requirements-dev.txt`, which installs
+the package's `dev` extra, before invoking the manual commands.
+
+## Reading deterministic test output
+
+- Twelve skipped live tests in the default suite are expected. They run only
+  when `GETBIBLE_RUN_LIVE_TESTS=1` is set.
+- The last-known-good refresh regression intentionally feeds an invalid corpus
+  to the cache. A logged `CacheIntegrityError` followed by that test's `ok` and
+  a final `OK` suite result is expected; it proves the invalid refresh was
+  rejected while the valid cached corpus remained available.
+- A nonzero command exit status or a final `FAILED`/`ERROR` result is a real
+  gate failure. The local script prints the final summary on success and the
+  last 200 log lines on failure, matching CI's failure diagnostics.
 
 ## Required adversarial cases
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,13 +9,14 @@
 ## Local development
 
 ```bash
-python -m venv .venv
-.venv/bin/python -m pip install -r requirements-dev.txt
-.venv/bin/python -m unittest discover -s tests -v
-.venv/bin/ruff check src tests benchmarks scripts examples
-.venv/bin/python -m build
-.venv/bin/python -m twine check dist/*
+./scripts/run_release_gate.sh
 ```
+
+This creates or reuses `.venv`, installs the development toolchain, and runs
+the deterministic tests, lint, security and dependency scans, package checks,
+and an isolated-wheel import. It avoids accidental reliance on globally
+installed tools. See the [release gate](RELEASE_GATE.md) for the individual
+commands, expected test diagnostics, and environment overrides.
 
 ## Deterministic tests
 
@@ -24,32 +25,37 @@ The default suite uses repository fixtures and does not depend on the public API
 ## Live integration
 
 ```bash
-GETBIBLE_RUN_LIVE_TESTS=1 .venv/bin/python -m unittest \
-  tests.test_getbible tests.test_live_search -v
+./scripts/run_release_gate.sh --live
 ```
 
-GitHub runs the live suite weekly and on manual dispatch. The scheduled job detects upstream API or fixture expectation drift without making pull-request CI dependent on the network.
+GitHub runs the **Live API Integration** workflow weekly and on manual dispatch.
+The scheduled job detects upstream API or fixture expectation drift without
+making pull-request CI dependent on the network.
 
 ## CI artifacts
 
-Every push and pull request to `master` or `staging` runs:
+Every push and pull request to `master` or `staging`, plus a manual **CI**
+workflow dispatch, runs:
 
 - Python 3.10–3.14 deterministic tests;
 - Ruff checks;
+- Bandit and dependency-advisory checks;
 - source and wheel builds;
 - Twine package validation;
+- installation and import of the wheel in isolation;
 - upload of the built distributions as a GitHub Actions artifact.
 
 The artifact can be downloaded and installed in a clean environment before release.
 
 ## Release preparation
 
-1. Confirm `staging` CI is green.
-2. Run the live integration workflow.
-3. Review `CHANGELOG.md` and replace `Unreleased` with the release date.
-4. Confirm the version in `pyproject.toml`.
-5. Merge the exact release state into `master`.
-6. Open the GitHub Actions **Release** workflow, choose **Run workflow**, and enter the version without the leading `v`.
+1. Run the local release gate and resolve every failure.
+2. Confirm the exact `staging` commit has a green **CI** workflow run.
+3. Manually run **Live API Integration** for the same `staging` commit.
+4. Review `CHANGELOG.md` and replace `Unreleased` with the release date.
+5. Confirm the version in `pyproject.toml`.
+6. Merge the exact release state into `master`.
+7. Open the GitHub Actions **Release** workflow, choose **Run workflow**, and enter the version without the leading `v`.
 
 The workflow freezes the current `master` SHA in its preparation job, requires
 the entered version to match `pyproject.toml`, and passes that exact SHA to

--- a/scripts/run_release_gate.sh
+++ b/scripts/run_release_gate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run_release_gate.sh [--live]
+
+Create or reuse the project virtual environment, install the development
+toolchain, and run the local release gate. Pass --live to run the opt-in live
+API integration tests after the deterministic gate succeeds.
+
+Environment variables:
+  PYTHON     Python interpreter used to create .venv (default: python3)
+  VENV_DIR   Virtual environment path (default: <repository>/.venv)
+EOF
+}
+
+run_live=0
+case "${1:-}" in
+  "") ;;
+  --live) run_live=1 ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+python_command="${PYTHON:-python3}"
+venv_dir="${VENV_DIR:-$repository_root/.venv}"
+
+if [[ ! -x "$venv_dir/bin/python" ]]; then
+  echo "Creating virtual environment with $python_command"
+  "$python_command" -m venv --clear --copies "$venv_dir"
+fi
+
+python="$venv_dir/bin/python"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/getbible-release-gate.XXXXXX")"
+trap 'rm -rf -- "$work_dir"' EXIT
+
+echo "Using $($python --version) from $venv_dir"
+echo "Installing the project development toolchain"
+"$python" -m pip install --upgrade pip
+"$python" -m pip install -r requirements-dev.txt
+
+echo "Compiling source and tests"
+"$python" -m compileall -q src tests
+
+echo "Running deterministic tests"
+test_log="$work_dir/deterministic-tests.log"
+if "$python" -m unittest discover -s tests -v >"$test_log" 2>&1; then
+  tail -n 5 "$test_log"
+else
+  tail -n 200 "$test_log" >&2
+  exit 1
+fi
+
+echo "Running lint and security checks"
+"$venv_dir/bin/ruff" check src tests benchmarks scripts examples
+"$venv_dir/bin/bandit" -q -r src/getbible -x src/getbible/data
+"$python" -m pip_audit --cache-dir "$work_dir/pip-audit-cache"
+
+echo "Building and validating distributions"
+dist_dir="$work_dir/dist"
+"$python" -m build --outdir "$dist_dir"
+"$python" -m twine check "$dist_dir"/*
+
+wheels=("$dist_dir"/*.whl)
+if [[ ! -f "${wheels[0]}" ]]; then
+  echo "The build did not produce a wheel." >&2
+  exit 1
+fi
+
+echo "Installing the wheel in an isolated environment"
+wheel_venv="$work_dir/wheel-venv"
+"$python" -m venv --copies "$wheel_venv"
+"$wheel_venv/bin/python" -m pip install "${wheels[0]}"
+(
+  cd "$work_dir"
+  "$wheel_venv/bin/python" -c "from getbible import GetBible, RequestLimits, SearchBible, SearchLimits, SourceGeneration; assert SearchBible().limit == 100; assert RequestLimits().max_references == 8; assert SearchLimits().max_work_units == 50000000; assert SourceGeneration('test', 0, 'initial', 0).cache_namespace == 'test:g0'; GetBible().close()"
+)
+
+if [[ "$run_live" -eq 1 ]]; then
+  echo "Running opt-in live API integration tests"
+  live_cache="$work_dir/live-cache"
+  GETBIBLE_RUN_LIVE_TESTS=1 GETBIBLE_CACHE_DIR="$live_cache" \
+    "$python" -m unittest tests.test_getbible tests.test_live_search -v
+fi
+
+echo "Local release gate passed."


### PR DESCRIPTION
## Summary

- document when to use the CI and Live API Integration workflows
- add a one-command local release gate that bootstraps all development tools inside `.venv`
- explain expected skipped live tests and the intentional last-known-good cache traceback
- validate the local gate entry point in CI and include it in source distributions

## Validation

- `bash -n scripts/run_release_gate.sh`
- `VENV_DIR=/tmp/getbible-release-gate-venv ./scripts/run_release_gate.sh`
  - 107 deterministic tests passed (12 expected live skips)
  - Ruff and Bandit passed
  - pip-audit found no known dependency vulnerabilities
  - source/wheel build and Twine checks passed
  - isolated wheel install/import passed

The GitHub CI workflow will run the authoritative Python 3.10–3.14 matrix. The separate Live API Integration workflow should be manually dispatched for this branch before release.