### PR TITLE
Harden multilingual scripture search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 All notable project changes are documented here.
 
-## [1.2.0] - Unreleased
+## [1.2.1] - Unreleased
+
+### Added
+
+- Deterministic multilingual search fixtures for Simplified and Traditional
+  Chinese, Japanese, Korean, Arabic, Hebrew, Devanagari, Thai, Lao, Khmer,
+  Myanmar, Persian join controls, and mixed-script queries.
+- `requires_substring_matching()` as the shared Unicode-property detector for
+  applications that offer automatic matching for continuous-writing scripts.
+- Search response `engine_version` metadata and the matching
+  `SEARCH_ENGINE_VERSION` constant for result-cache invalidation when matching
+  semantics change without a translation SHA change.
+- Per-item and aggregate character budgets for book-name and exclusion
+  filters.
+
+### Fixed
+
+- Short substring searches now accept meaningful Han, kana, Hangul, and
+  Unicode complex-context terms without lowering the global Latin/segmented
+  script minimum.
+- Substring matches now report every non-overlapping occurrence inside one
+  uninterrupted token and charge that work conservatively.
+- Grapheme-aware validation prevents punctuation and combining marks from
+  padding undersized substring terms.
+- ZWNJ and ZWJ no longer split otherwise continuous Arabic-script and Indic
+  words.
+
+## [1.2.0] - 2026-07-20
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Search responses contain three top-level objects:
 
 This keeps existing scripture templates reusable. With relevance sorting, `matches` is the authoritative cross-chapter order.
 
+Substring search is script-aware. One- and two-character terms remain blocked
+for Latin and other normally space-delimited scripts, while meaningful short
+terms are supported for Han, Japanese kana, Hangul, and Unicode
+complex-context scripts such as Thai, Lao, Khmer, and Myanmar. Arabic, Hebrew,
+Devanagari, Greek, Cyrillic, and other space-delimited scripts retain Unicode
+whole-word behavior. See [Scripture search](docs/SEARCH.md) for the matching
+policy and shared continuous-writing-script detector.
+
 Search criteria may also be supplied as a JSON-decoded dictionary:
 
 ```python

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -87,6 +87,26 @@ with limiter.reserve(caller_identity, tier=rate_tier):
     response = bible.search(query, translation, criteria)
 ```
 
+If the public service offers an automatic match choice, apply it only when the
+request omitted `match`:
+
+```python
+from getbible import requires_substring_matching
+
+
+if (
+    "match" not in validated_filter_values
+    and requires_substring_matching(query)
+):
+    validated_filter_values["match"] = "substring"
+```
+
+The helper uses Unicode Script Extensions and Complex Context line-breaking
+properties. It selects continuous-writing scripts such as Han, Japanese,
+Thai, Lao, Khmer, and Myanmar without incorrectly classifying Arabic, Hebrew,
+Devanagari, or Hangul as unsegmented. An explicitly supplied match mode must
+remain authoritative.
+
 Do not pass raw query values through Python truthiness (`bool("false")` is
 `True`), silently ignore unknown filters, or expose regular expressions.
 
@@ -136,6 +156,11 @@ The search response `query.sha` identifies the exact translation payload and
 text by default; application and reverse-proxy access logs should retain
 request identifiers, lengths, counts, status, and timing without recording the
 query string.
+
+Include `query.engine_version` with `query.sha` in response-cache namespaces.
+Use the exported `SEARCH_ENGINE_VERSION` constant while constructing a cache
+key before executing a search. The translation SHA alone cannot invalidate
+cached totals when search tokenization or matching semantics change.
 
 For a shared Redis, Memcached, filesystem, or proxy response cache, wrap the
 entire lookup/call/write transaction in `source_operation()` and prefix the key

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -21,7 +21,11 @@ bible = GetBible(
         max_query_terms=64,
         min_substring_length=3,
         max_books=83,
+        max_book_length=256,
+        max_books_length=4_096,
         max_exclusions=32,
+        max_exclusion_length=500,
+        max_exclusions_length=4_000,
         max_exclusion_terms=64,
         max_offset=10_000,
         max_limit=1_000,
@@ -42,8 +46,16 @@ building an index, scanning postings, testing phrases, and evaluating
 proximity. The response is serialized into the configured byte budget before
 it is returned.
 
-Substring terms must contain at least three characters by default. This stops
-one-character vocabulary scans before the translation corpus is loaded.
+Substring terms must contain at least three extended grapheme clusters by
+default. This stops one-character vocabulary scans before the translation
+corpus is loaded. Script-tailored exceptions permit meaningful short Han,
+Japanese kana, Hangul, and Unicode complex-context terms while retaining the
+minimum for Latin and normally space-delimited scripts. Punctuation and
+combining marks cannot pad a short term past the limit.
+
+Book-name and exclusion filters have both per-item and aggregate character
+budgets. These checks run before repository access and prevent oversized
+criteria from consuming normalization work or being echoed into a response.
 `SearchBible.expensive` classifies substring, phrase, any-word, proximity,
 relevance, exclusion, insensitive-diacritic, deep-offset, and large-page
 criteria before execution so the HTTP layer can apply its strict rate tier.

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -89,6 +89,9 @@ the package's `dev` extra, before invoking the manual commands.
 - repository traversal is rejected;
 - blank and excessive search inputs fail before translation loading;
 - substring, deterministic work, output-volume, filter, and cooperative deadline budgets fail closed;
+- short continuous-writing-script searches remain bounded while short Latin and other segmented-script substrings fail before repository access;
+- punctuation, combining marks, oversized exclusions, and oversized book filters cannot bypass pre-execution limits;
+- multilingual fixtures cover Han, kana, Hangul, Arabic, Hebrew, Devanagari, Thai, Lao, Khmer, Myanmar, and Unicode join controls;
 - full corpora and independent books indexes are completely validated before a versioned content-addressed payload is committed;
 - production full-translation and chapter checksums are required and compared;
 - invalid upstream refreshes preserve the last-known-good corpus;

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -103,11 +103,50 @@ Whole-word matching uses Unicode letter, combining-mark, and number boundaries. 
 
 Substring matching searches inside normalized tokens. For example, `great` can match `greatest`.
 
+The distinction remains explicit and deterministic: Librarian never silently
+rewrites a requested `whole_word` search. For languages that do not reliably
+separate words with spaces, applications should select `substring`.
+
+Librarian permits one- and two-grapheme substring terms only when the complete
+term uses Han, Japanese kana, Hangul, or a Unicode complex-context script such
+as Thai, Lao, Khmer, or Myanmar. The configured minimum remains in force for
+Latin, Arabic, Hebrew, Devanagari, Greek, Cyrillic, and other normally
+space-delimited scripts. Mixed short tokens such as `a神` are rejected.
+
+Applications can share Librarian's Unicode-property detector instead of
+maintaining character ranges:
+
+```python
+from getbible import requires_substring_matching
+
+
+match = (
+    "substring"
+    if requires_substring_matching(query)
+    else "whole_word"
+)
+```
+
+Use that automatic choice only when the caller has not explicitly selected a
+match mode. For a query mixing continuous-writing and space-delimited terms,
+keep the choice explicit: applying substring matching to the entire query also
+allows partial matches for its Latin or other space-delimited terms.
+
+Substring occurrence counts and relevance scores include every non-overlapping
+occurrence inside a token. Join controls (ZWNJ and ZWJ) remain part of the
+surrounding Arabic-script or Indic token instead of creating false word
+boundaries.
+
 ## Case and diacritics
 
 Case-insensitive matching uses Unicode `casefold()`. Original verse text is never modified in the response.
 
 Diacritic-insensitive matching decomposes Unicode characters and removes combining marks from the search index. This can make `Cafe` match `Café` and can ignore Hebrew vowel marks. It does not perform transliteration.
+
+This option is never enabled automatically. Some scripts, including
+Devanagari and Southeast Asian scripts, use combining marks structurally, so
+callers should request insensitive matching only when it is appropriate for
+the selected translation.
 
 ## Testament and book scopes
 
@@ -136,6 +175,7 @@ Canonical ordering follows API book, chapter, and verse order. Relevance orderin
 query
   text
   criteria
+  engine_version
   translation
   sha
   total
@@ -169,6 +209,12 @@ matches
 `matches` preserves global search order. This is especially important for relevance sorting because `results` groups verses by chapter.
 
 The `sha` field identifies the exact full-translation payload used for the search, enabling downstream response-cache invalidation.
+
+`engine_version` identifies result-affecting search semantics independently of
+the translation SHA. Search response caches should include both values in
+their namespace and must be flushed when upgrading from an implementation that
+did not include the engine version. `SEARCH_ENGINE_VERSION` exports the same
+integer for cache-key construction before a search executes.
 
 `cost.work_units` is the deterministic estimate enforced by
 `SearchLimits.max_work_units`; it is suitable for aggregate metrics but is not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "getbible"
-version = "1.2.0"
+version = "1.2.1"
 description = "Retrieve and search Bible scripture through the GetBible API."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/getbible/__init__.py
+++ b/src/getbible/__init__.py
@@ -16,7 +16,13 @@ from .exceptions import (
 from .getbible_book_number import GetBibleBookNumber
 from .getbible_reference import BookReference, GetBibleReference
 from .hardened import GetBible, RequestLimits
-from .search import SearchBible, SearchCriteria, SearchLimits
+from .search import (
+    SEARCH_ENGINE_VERSION,
+    SearchBible,
+    SearchCriteria,
+    SearchLimits,
+    requires_substring_matching,
+)
 from .source_generation import SourceGeneration
 
 __all__ = [
@@ -34,6 +40,7 @@ __all__ = [
     "RepositoryTimeoutError",
     "RequestLimitError",
     "RequestLimits",
+    "SEARCH_ENGINE_VERSION",
     "SearchBible",
     "SearchCriteria",
     "SearchDeadlineExceeded",
@@ -42,4 +49,5 @@ __all__ = [
     "SearchValidationError",
     "SourceGeneration",
     "TranslationNotFoundError",
+    "requires_substring_matching",
 ]

--- a/src/getbible/getbible.py
+++ b/src/getbible/getbible.py
@@ -456,6 +456,7 @@ class GetBible:
             "query": {
                 "text": query,
                 "criteria": criteria.to_dict(),
+                "engine_version": execution_info["engine_version"],
                 "translation": deepcopy(corpus.translation_metadata),
                 "sha": corpus.sha,
                 "total": total,

--- a/src/getbible/search.py
+++ b/src/getbible/search.py
@@ -22,13 +22,37 @@ from .exceptions import (
 )
 from .translation_cache import TranslationSnapshot
 
-_WORD_CHARACTER_CLASS = r"\p{L}\p{M}\p{N}"
-_TOKEN = regex.compile(rf"[{_WORD_CHARACTER_CLASS}]+(?:['’][{_WORD_CHARACTER_CLASS}]+)*")
+_WORD_START_CHARACTER_CLASS = r"\p{L}\p{N}"
+_WORD_CHARACTER_CLASS = rf"{_WORD_START_CHARACTER_CLASS}\p{{M}}\u200C\u200D"
+_TOKEN = regex.compile(
+    rf"[{_WORD_START_CHARACTER_CLASS}][{_WORD_CHARACTER_CLASS}]*"
+    rf"(?:['’][{_WORD_START_CHARACTER_CLASS}][{_WORD_CHARACTER_CLASS}]*)*"
+)
+_GRAPHEME = regex.compile(r"\X")
+_CONTINUOUS_WRITING_SCRIPT_CLASS = (
+    r"\p{Script_Extensions=Han}"
+    r"\p{Script_Extensions=Hiragana}"
+    r"\p{Script_Extensions=Katakana}"
+    r"\p{Line_Break=Complex_Context}"
+)
+_SHORT_SUBSTRING_SCRIPT_CLASS = (
+    _CONTINUOUS_WRITING_SCRIPT_CLASS + r"\p{Script_Extensions=Hangul}"
+)
+_CONTINUOUS_WRITING_SCRIPT = regex.compile(
+    rf"[{_CONTINUOUS_WRITING_SCRIPT_CLASS}]"
+)
+_SHORT_SUBSTRING_TERM = regex.compile(
+    rf"(?V1)\A"
+    rf"(?=[{_WORD_CHARACTER_CLASS}]*[{_SHORT_SUBSTRING_SCRIPT_CLASS}])"
+    rf"[{_SHORT_SUBSTRING_SCRIPT_CLASS}\p{{M}}\p{{N}}\u200C\u200D]+"
+    rf"\Z"
+)
 _VALID_WORDS = frozenset({"all", "any", "phrase"})
 _VALID_MATCH = frozenset({"whole_word", "substring"})
 _VALID_SCOPE = frozenset({"bible", "old_testament", "new_testament", "deuterocanon"})
 _VALID_DIACRITICS = frozenset({"sensitive", "insensitive"})
 _VALID_SORT = frozenset({"canonical", "relevance"})
+SEARCH_ENGINE_VERSION = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,7 +65,11 @@ class SearchLimits:
     max_query_terms: int = 64
     min_substring_length: int = 3
     max_books: int = 83
+    max_book_length: int = 256
+    max_books_length: int = 4_096
     max_exclusions: int = 32
+    max_exclusion_length: int = 500
+    max_exclusions_length: int = 4_000
     max_exclusion_terms: int = 64
     max_offset: int = 10_000
     max_limit: int = 1_000
@@ -56,7 +84,11 @@ class SearchLimits:
             "max_query_terms",
             "min_substring_length",
             "max_books",
+            "max_book_length",
+            "max_books_length",
             "max_exclusions",
+            "max_exclusion_length",
+            "max_exclusions_length",
             "max_exclusion_terms",
             "max_limit",
             "deadline_check_interval",
@@ -504,9 +536,29 @@ def validate_search_request(
         raise SearchLimitError(
             f"Search cannot select more than {limits.max_books} books."
         )
+    book_names = tuple(book for book in criteria.books if isinstance(book, str))
+    if any(len(book) > limits.max_book_length for book in book_names):
+        raise SearchLimitError(
+            f"Search book names cannot exceed {limits.max_book_length} characters."
+        )
+    if sum(map(len, book_names)) > limits.max_books_length:
+        raise SearchLimitError(
+            "Search book names cannot contain more than "
+            f"{limits.max_books_length} characters in total."
+        )
     if len(criteria.exclude) > limits.max_exclusions:
         raise SearchLimitError(
             f"Search cannot contain more than {limits.max_exclusions} exclusions."
+        )
+    if any(len(term) > limits.max_exclusion_length for term in criteria.exclude):
+        raise SearchLimitError(
+            "Search exclusions cannot exceed "
+            f"{limits.max_exclusion_length} characters each."
+        )
+    if sum(map(len, criteria.exclude)) > limits.max_exclusions_length:
+        raise SearchLimitError(
+            "Search exclusions cannot contain more than "
+            f"{limits.max_exclusions_length} characters in total."
         )
 
     normalized_query = normalize_text(
@@ -533,18 +585,16 @@ def validate_search_request(
             "Search exclusions cannot contain more than "
             f"{limits.max_exclusion_terms} terms."
         )
-    if criteria.match == "substring":
-        searched_values = (
-            (normalized_query,) if criteria.words == "phrase" else query_terms
+    if criteria.match == "substring" and any(
+        len(_GRAPHEME.findall(term)) < limits.min_substring_length
+        and not allows_short_substring(term)
+        for term in (*query_terms, *excluded_terms)
+    ):
+        raise SearchValidationError(
+            "Substring search terms must contain at least "
+            f"{limits.min_substring_length} characters unless they use a "
+            "supported continuous-writing script."
         )
-        if any(
-            len(term) < limits.min_substring_length
-            for term in (*searched_values, *excluded_terms)
-        ):
-            raise SearchValidationError(
-                "Substring search terms must contain at least "
-                f"{limits.min_substring_length} characters."
-            )
     return stripped_query, normalized_query, query_terms, excluded, excluded_terms
 
 
@@ -683,9 +733,12 @@ class SearchEngine:
             for position, (token, ordinals) in enumerate(index.postings.items()):
                 budget.checkpoint(position)
                 for term in terms:
-                    units += 1 + min(len(token), len(term))
-                    if term in token:
-                        units += len(ordinals)
+                    occurrences = token.count(term)
+                    units += 1 + len(token)
+                    if occurrences:
+                        units += len(ordinals) * occurrences
+                    if units > budget.limits.max_work_units:
+                        budget.reserve(units)
             if criteria.words == "phrase":
                 units += sum(len(text) for text in index.texts)
         else:
@@ -703,6 +756,7 @@ class SearchEngine:
     def _finish_execution(self, budget: SearchBudget, criteria: SearchBible) -> None:
         budget.check_deadline()
         self.execution_info = {
+            "engine_version": SEARCH_ENGINE_VERSION,
             "work_units": budget.work_units,
             "deadline_seconds": float(self.limits.deadline_seconds),
             "elapsed_seconds": budget.elapsed_seconds,
@@ -834,8 +888,10 @@ class _Matcher:
         counts: Counter[int] = Counter()
         for position, (token, ordinals) in enumerate(index.postings.items()):
             self.budget.checkpoint(position)
-            if term in token:
-                counts.update(ordinals)
+            occurrences = token.count(term)
+            if occurrences:
+                for ordinal in ordinals:
+                    counts[ordinal] += occurrences
         return counts
 
     def _excluded_ordinals(self, index: SearchIndex) -> set[int]:
@@ -891,6 +947,31 @@ def normalize_text(text: str, case_sensitive: bool, diacritics: str) -> str:
         )
         value = unicodedata.normalize("NFC", value)
     return value if case_sensitive else value.casefold()
+
+
+def allows_short_substring(term: str) -> bool:
+    """Return whether a term uses scripts where short units carry word meaning.
+
+    Han, Japanese kana, Hangul, and Unicode complex-context scripts cannot
+    always rely on spaces to delimit every searchable unit. Restricting these
+    terms to the global substring minimum would reject ordinary one- or
+    two-character searches. Mixed Latin/script tokens stay subject to the
+    global minimum.
+    """
+    return bool(_SHORT_SUBSTRING_TERM.fullmatch(term))
+
+
+def requires_substring_matching(query: str) -> bool:
+    """Return whether a query contains text without reliable space boundaries.
+
+    Applications that provide a search-engine-style default can use this
+    helper to convert ``whole_word`` to ``substring`` without maintaining
+    their own incomplete script detector. Explicit Librarian match modes
+    remain deterministic and are never silently rewritten.
+    """
+    if not isinstance(query, str):
+        raise TypeError("query must be a string.")
+    return bool(_CONTINUOUS_WRITING_SCRIPT.search(query))
 
 
 def normalize_book_name(name: str) -> str:

--- a/tests/fixtures/multilingual_repository/v2/multi.json
+++ b/tests/fixtures/multilingual_repository/v2/multi.json
@@ -1,0 +1,156 @@
+{
+  "translation": "Multilingual Search Test Translation",
+  "abbreviation": "multi",
+  "description": "Deterministic offline fixture for multilingual Unicode search tests.",
+  "lang": "mul",
+  "language": "Multilingual",
+  "direction": "LTR",
+  "encoding": "UTF-8",
+  "distribution_license": "Test data only",
+  "books": [
+    {
+      "nr": 1,
+      "name": "Multilingual",
+      "chapters": [
+        {
+          "chapter": 1,
+          "name": "Multilingual 1",
+          "verses": [
+            {
+              "chapter": 1,
+              "verse": 1,
+              "name": "Multilingual 1:1",
+              "text": "起初，神创造天地；神爱世人。"
+            },
+            {
+              "chapter": 1,
+              "verse": 2,
+              "name": "Multilingual 1:2",
+              "text": "神爱世人，也赐下永生。"
+            },
+            {
+              "chapter": 1,
+              "verse": 3,
+              "name": "Multilingual 1:3",
+              "text": "起初，神創造天地；神愛世人。"
+            },
+            {
+              "chapter": 1,
+              "verse": 4,
+              "name": "Multilingual 1:4",
+              "text": "初めに、神は天と地を創造された。神は世を愛された。"
+            },
+            {
+              "chapter": 1,
+              "verse": 5,
+              "name": "Multilingual 1:5",
+              "text": "태초에 하나님이 천지를 창조하시니라. 하나님이 세상을 사랑하셨다."
+            },
+            {
+              "chapter": 1,
+              "verse": 6,
+              "name": "Multilingual 1:6",
+              "text": "فِي الْبَدْءِ خَلَقَ اللهُ السَّمَاوَاتِ وَالأَرْضَ."
+            },
+            {
+              "chapter": 1,
+              "verse": 7,
+              "name": "Multilingual 1:7",
+              "text": "في البدء كانت الكلمة، ثم الكلمة كانت عند الله."
+            },
+            {
+              "chapter": 1,
+              "verse": 8,
+              "name": "Multilingual 1:8",
+              "text": "بِالْبَدْءِ إله واحد."
+            },
+            {
+              "chapter": 1,
+              "verse": 9,
+              "name": "Multilingual 1:9",
+              "text": "בְּרֵאשִׁית בָּרָא אֱלֹהִים אֵת הַשָּׁמַיִם וְאֵת הָאָרֶץ׃"
+            },
+            {
+              "chapter": 1,
+              "verse": 10,
+              "name": "Multilingual 1:10",
+              "text": "בראשית ברא אלהים את השמים ואת הארץ."
+            },
+            {
+              "chapter": 1,
+              "verse": 11,
+              "name": "Multilingual 1:11",
+              "text": "आदि में परमेश्वर ने आकाश और पृथ्वी की सृष्टि की।"
+            },
+            {
+              "chapter": 1,
+              "verse": 12,
+              "name": "Multilingual 1:12",
+              "text": "यीशु ने कहा, क़ानून और सत्य स्थिर हैं।"
+            },
+            {
+              "chapter": 1,
+              "verse": 13,
+              "name": "Multilingual 1:13",
+              "text": "ในปฐมกาลพระเจ้าทรงเนรมิตสร้างฟ้าและแผ่นดิน"
+            },
+            {
+              "chapter": 1,
+              "verse": 14,
+              "name": "Multilingual 1:14",
+              "text": "เพราะว่าพระเจ้าทรงรักโลกและประทานชีวิตนิรันดร์"
+            },
+            {
+              "chapter": 1,
+              "verse": 15,
+              "name": "Multilingual 1:15",
+              "text": "Jesus—耶稣—イエス—예수 ประกาศข่าวดี."
+            },
+            {
+              "chapter": 1,
+              "verse": 16,
+              "name": "Multilingual 1:16",
+              "text": "ໃນຕອນເລີ່ມຕົ້ນ ພຣະເຈົ້າຊົງສ້າງຟ້າແລະແຜ່ນດິນ."
+            },
+            {
+              "chapter": 1,
+              "verse": 17,
+              "name": "Multilingual 1:17",
+              "text": "កាលដើមដំបូង ព្រះបានបង្កើតផ្ទៃមេឃ និងផែនដី។"
+            },
+            {
+              "chapter": 1,
+              "verse": 18,
+              "name": "Multilingual 1:18",
+              "text": "အစအဦး၌ ဘုရားသခင်သည် ကောင်းကင်နှင့် မြေကြီးကို ဖန်ဆင်းတော်မူ၏။"
+            },
+            {
+              "chapter": 1,
+              "verse": 19,
+              "name": "Multilingual 1:19",
+              "text": "神神创造神。"
+            },
+            {
+              "chapter": 1,
+              "verse": 20,
+              "name": "Multilingual 1:20",
+              "text": "アーメン、主をほめたたえよ。"
+            },
+            {
+              "chapter": 1,
+              "verse": 21,
+              "name": "Multilingual 1:21",
+              "text": "در آغاز خدا می‌رود و راه را می‌گشاید."
+            },
+            {
+              "chapter": 1,
+              "verse": 22,
+              "name": "Multilingual 1:22",
+              "text": "क्‍ष सत्य है।"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/multilingual_repository/v2/multi/books.json
+++ b/tests/fixtures/multilingual_repository/v2/multi/books.json
@@ -1,0 +1,12 @@
+{
+  "1": {
+    "translation": "Multilingual Search Test Translation",
+    "abbreviation": "multi",
+    "lang": "mul",
+    "language": "Multilingual",
+    "direction": "LTR",
+    "encoding": "UTF-8",
+    "nr": 1,
+    "name": "Multilingual"
+  }
+}

--- a/tests/test_multilingual_search.py
+++ b/tests/test_multilingual_search.py
@@ -1,0 +1,232 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from getbible import GetBible, SearchBible, SearchValidationError
+
+FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "multilingual_repository"
+
+
+class TestMultilingualSearch(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.bible = GetBible(
+            repo_path=FIXTURE_REPOSITORY,
+            cache_dir=self.temporary.name,
+        )
+
+    def tearDown(self) -> None:
+        self.bible.close()
+        self.temporary.cleanup()
+
+    def _search(
+        self,
+        query: str,
+        *,
+        match: str = "whole_word",
+        words: str = "all",
+        diacritics: str = "sensitive",
+        exclude: tuple[str, ...] = (),
+    ) -> dict:
+        return self.bible.search(
+            query,
+            "multi",
+            SearchBible(
+                match=match,
+                words=words,
+                diacritics=diacritics,
+                exclude=exclude,
+            ),
+        )
+
+    @staticmethod
+    def _verse_numbers(response: dict) -> list[int]:
+        return [int(match["verse"]) for match in response["matches"]]
+
+    def test_simplified_chinese_short_substrings_match_inside_unsegmented_text(
+        self,
+    ) -> None:
+        one_character = self._search("神", match="substring")
+        two_characters = self._search("神爱", match="substring")
+
+        self.assertEqual(self._verse_numbers(one_character), [1, 2, 3, 4, 19])
+        self.assertEqual(self._verse_numbers(two_characters), [1, 2])
+        self.assertEqual(two_characters["query"]["total"], 2)
+        self.assertEqual(two_characters["query"]["engine_version"], 2)
+
+    def test_repeated_han_substrings_report_every_occurrence_in_one_token(
+        self,
+    ) -> None:
+        response = self._search("神", match="substring")
+        repeated = next(
+            match for match in response["matches"] if int(match["verse"]) == 19
+        )
+
+        self.assertEqual(repeated["occurrences"], 3)
+
+    def test_traditional_chinese_is_searched_without_conflating_script_variants(
+        self,
+    ) -> None:
+        traditional = self._search("神愛", match="substring")
+        simplified = self._search("神爱", match="substring")
+
+        self.assertEqual(self._verse_numbers(traditional), [3])
+        self.assertEqual(self._verse_numbers(simplified), [1, 2])
+
+    def test_chinese_punctuation_creates_a_whole_word_boundary(self) -> None:
+        response = self._search("起初")
+
+        self.assertEqual(self._verse_numbers(response), [1, 3])
+        self.assertEqual(response["query"]["total"], 2)
+
+    def test_whole_word_does_not_claim_an_internal_chinese_match(self) -> None:
+        response = self._search("神")
+
+        self.assertEqual(response["query"]["total"], 0)
+        self.assertEqual(response["matches"], [])
+
+    def test_japanese_short_substring_matches_inside_an_unsegmented_token(
+        self,
+    ) -> None:
+        substring = self._search("めに", match="substring")
+        whole_word = self._search("めに")
+
+        self.assertEqual(self._verse_numbers(substring), [4])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_japanese_short_substring_accepts_prolonged_sound_mark(self) -> None:
+        substring = self._search("アー", match="substring")
+        whole_word = self._search("アー")
+
+        self.assertEqual(self._verse_numbers(substring), [20])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_korean_short_substring_matches_an_inflected_word(self) -> None:
+        substring = self._search("천지", match="substring")
+        whole_word = self._search("천지")
+
+        self.assertEqual(self._verse_numbers(substring), [5])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_thai_short_substring_matches_text_without_spaces(self) -> None:
+        substring = self._search("ใน", match="substring")
+        whole_word = self._search("ใน")
+
+        self.assertEqual(self._verse_numbers(substring), [13])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_lao_short_substring_matches_text_without_word_boundaries(self) -> None:
+        substring = self._search("ໃນ", match="substring")
+        whole_word = self._search("ໃນ")
+
+        self.assertEqual(self._verse_numbers(substring), [16])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_khmer_short_substring_matches_text_without_word_boundaries(self) -> None:
+        substring = self._search("កា", match="substring")
+        whole_word = self._search("កា")
+
+        self.assertEqual(self._verse_numbers(substring), [17])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_myanmar_short_substring_matches_text_without_word_boundaries(self) -> None:
+        substring = self._search("အစ", match="substring")
+        whole_word = self._search("အစ")
+
+        self.assertEqual(self._verse_numbers(substring), [18])
+        self.assertEqual(whole_word["query"]["total"], 0)
+
+    def test_mixed_scripts_remain_searchable_across_unicode_punctuation(self) -> None:
+        response = self._search(
+            "Jesus 耶稣",
+            match="substring",
+            words="all",
+        )
+
+        self.assertEqual(self._verse_numbers(response), [15])
+        self.assertEqual(response["matches"][0]["terms"], ["jesus", "耶稣"])
+
+    def test_short_unsegmented_exclusion_uses_the_same_validation_policy(
+        self,
+    ) -> None:
+        response = self._search(
+            "起初",
+            match="substring",
+            exclude=("爱",),
+        )
+
+        self.assertEqual(self._verse_numbers(response), [3])
+        self.assertEqual(response["query"]["total"], 1)
+
+    def test_arabic_whole_words_and_arabic_comma_are_tokenized_correctly(
+        self,
+    ) -> None:
+        response = self._search("الكلمة")
+
+        self.assertEqual(self._verse_numbers(response), [7])
+        self.assertEqual(response["matches"][0]["occurrences"], 2)
+
+    def test_arabic_diacritic_insensitive_search_matches_pointed_text(self) -> None:
+        sensitive = self._search("في")
+        insensitive = self._search("في", diacritics="insensitive")
+
+        self.assertEqual(self._verse_numbers(sensitive), [7])
+        self.assertEqual(self._verse_numbers(insensitive), [6, 7])
+
+    def test_arabic_canonical_equivalence_is_normalized_to_nfc(self) -> None:
+        response = self._search("ا\u0655له")
+
+        self.assertEqual(self._verse_numbers(response), [8])
+        self.assertEqual(response["matches"][0]["terms"], ["إله"])
+
+    def test_hebrew_diacritic_insensitive_search_matches_pointed_text(self) -> None:
+        sensitive = self._search("בראשית")
+        insensitive = self._search("בראשית", diacritics="insensitive")
+
+        self.assertEqual(self._verse_numbers(sensitive), [10])
+        self.assertEqual(self._verse_numbers(insensitive), [9, 10])
+
+    def test_short_hebrew_whole_word_is_not_blocked_by_substring_limits(
+        self,
+    ) -> None:
+        response = self._search("את", diacritics="insensitive")
+
+        self.assertEqual(self._verse_numbers(response), [9, 10])
+        self.assertEqual(response["matches"][0]["occurrences"], 1)
+        self.assertEqual(response["matches"][1]["occurrences"], 1)
+
+    def test_devanagari_whole_words_respect_spaces_and_danda_punctuation(
+        self,
+    ) -> None:
+        response = self._search("की")
+
+        self.assertEqual(self._verse_numbers(response), [11])
+        self.assertEqual(response["matches"][0]["occurrences"], 2)
+
+    def test_devanagari_canonical_equivalence_normalizes_nukta_forms(self) -> None:
+        response = self._search("क़ानून")
+
+        self.assertEqual(self._verse_numbers(response), [12])
+        self.assertEqual(response["matches"][0]["terms"], ["क़ानून"])
+
+    def test_join_controls_remain_inside_arabic_and_devanagari_tokens(self) -> None:
+        persian = self._search("می‌رود")
+        devanagari = self._search("क्‍ष")
+
+        self.assertEqual(self._verse_numbers(persian), [21])
+        self.assertEqual(self._verse_numbers(devanagari), [22])
+
+    def test_short_substring_floor_remains_for_segmented_scripts(self) -> None:
+        for query in ("go", "في", "את", "की"):
+            with self.subTest(query=query), self.assertRaises(SearchValidationError):
+                self._search(query, match="substring")
+
+    def test_mixed_latin_and_han_short_token_cannot_bypass_substring_floor(
+        self,
+    ) -> None:
+        with self.assertRaises(SearchValidationError):
+            self._search("a神", match="substring")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multilingual_search_limits.py
+++ b/tests/test_multilingual_search_limits.py
@@ -1,0 +1,171 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from getbible import (
+    SEARCH_ENGINE_VERSION,
+    GetBible,
+    SearchBible,
+    SearchLimitError,
+    SearchLimits,
+    SearchValidationError,
+    requires_substring_matching,
+)
+from getbible.search import _Matcher
+
+FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "multilingual_repository"
+
+
+class TestMultilingualSearchLimits(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _bible(self, limits: SearchLimits | None = None) -> GetBible:
+        bible = GetBible(
+            repo_path=FIXTURE_REPOSITORY,
+            cache_dir=self.temporary.name,
+            search_limits=limits,
+        )
+        self.addCleanup(bible.close)
+        return bible
+
+    def test_filter_size_limits_reject_before_repository_access(self) -> None:
+        bible = self._bible()
+        oversized_filters = {
+            "book item": SearchBible(books=("b" * 257,)),
+            "book aggregate": SearchBible(books=("b" * 256,) * 17),
+            "exclusion item": SearchBible(exclude=("x" * 501,)),
+            "exclusion aggregate": SearchBible(exclude=("x" * 500,) * 9),
+        }
+
+        with (
+            patch.object(bible, "valid_translation") as valid_translation,
+            patch.object(bible._translation_cache, "load") as load_translation,
+        ):
+            for name, criteria in oversized_filters.items():
+                with self.subTest(name=name), self.assertRaises(SearchLimitError):
+                    bible.search("faith", "multi", criteria)
+
+        valid_translation.assert_not_called()
+        load_translation.assert_not_called()
+
+    def test_punctuation_cannot_pad_a_short_segmented_phrase(self) -> None:
+        bible = self._bible()
+
+        with (
+            patch.object(bible, "valid_translation") as valid_translation,
+            patch.object(bible._translation_cache, "load") as load_translation,
+            self.assertRaises(SearchValidationError),
+        ):
+            bible.search(
+                "a!!",
+                "multi",
+                SearchBible(words="phrase", match="substring"),
+            )
+
+        valid_translation.assert_not_called()
+        load_translation.assert_not_called()
+
+    def test_combining_marks_cannot_pad_a_short_arabic_substring(self) -> None:
+        bible = self._bible()
+
+        with (
+            patch.object(bible, "valid_translation") as valid_translation,
+            patch.object(bible._translation_cache, "load") as load_translation,
+            self.assertRaises(SearchValidationError),
+        ):
+            bible.search(
+                "فِي",
+                "multi",
+                SearchBible(match="substring"),
+            )
+
+        valid_translation.assert_not_called()
+        load_translation.assert_not_called()
+
+    def test_standalone_combining_marks_are_not_search_terms(self) -> None:
+        bible = self._bible()
+
+        with (
+            patch.object(bible, "valid_translation") as valid_translation,
+            patch.object(bible._translation_cache, "load") as load_translation,
+            self.assertRaises(SearchValidationError),
+        ):
+            bible.search("\u0301\u0650", "multi")
+
+        valid_translation.assert_not_called()
+        load_translation.assert_not_called()
+
+    def test_public_helper_detects_continuous_writing_scripts(self) -> None:
+        self.assertEqual(SEARCH_ENGINE_VERSION, 2)
+
+        detected = {
+            "Han": "神",
+            "Hiragana": "め",
+            "Katakana": "カー",
+            "Thai": "ใน",
+            "Lao": "ໃນ",
+            "Khmer": "ការ",
+            "Myanmar": "အစ",
+            "Buginese": "ᨠᨱ",
+        }
+        not_detected = {
+            "Hangul": "한글",
+            "Arabic": "العربية",
+            "Hebrew": "עברית",
+            "Devanagari": "देव",
+            "Latin": "faith",
+        }
+
+        for script, query in detected.items():
+            with self.subTest(script=script):
+                self.assertTrue(requires_substring_matching(query))
+        for script, query in not_detected.items():
+            with self.subTest(script=script):
+                self.assertFalse(requires_substring_matching(query))
+
+        with self.assertRaises(TypeError):
+            requires_substring_matching(None)  # type: ignore[arg-type]
+
+    def test_short_unsegmented_terms_fit_a_tight_deterministic_budget(self) -> None:
+        limits = SearchLimits(max_work_units=4_000)
+        bible = self._bible(limits)
+
+        for query, expected_total in (("神", 5), ("神爱", 2)):
+            with self.subTest(query=query):
+                response = bible.search(
+                    query,
+                    "multi",
+                    SearchBible(match="substring"),
+                )
+                self.assertEqual(response["query"]["total"], expected_total)
+                self.assertLessEqual(
+                    response["query"]["cost"]["work_units"],
+                    limits.max_work_units,
+                )
+
+    def test_pathological_multiterm_scan_is_rejected_before_matching(self) -> None:
+        limits = SearchLimits(max_work_units=4_000)
+        bible = self._bible(limits)
+        bible.warm_translation("multi")
+        query = "神 爱 天 地 起 初 生 命 道 光 日 月 人 子 王 国"
+
+        with (
+            patch.object(_Matcher, "search", wraps=_Matcher.search) as match,
+            self.assertRaisesRegex(SearchLimitError, "configured maximum"),
+        ):
+            bible.search(
+                query,
+                "multi",
+                SearchBible(words="any", match="substring"),
+            )
+
+        match.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow one- and two-grapheme substring searches for Han, Japanese kana, Hangul, and Unicode complex-context scripts without lowering the global minimum for Latin and normally space-delimited scripts
- add deterministic offline coverage for Simplified and Traditional Chinese, Japanese, Korean, Arabic, Hebrew, Devanagari, Thai, Lao, Khmer, Myanmar, Persian/Indic join controls, mixed scripts, exclusions, normalization, and occurrence counts
- export `requires_substring_matching()` so Robot and other clients can share one Unicode-property detector while explicit Librarian match modes remain authoritative
- correct substring occurrence scoring inside uninterrupted tokens and conservatively account for vocabulary-scan work
- close punctuation/combining-mark validation bypasses and bound book/exclusion text before repository access
- add search engine version 2 metadata and `SEARCH_ENGINE_VERSION` for safe response-cache invalidation
- prepare package and changelog metadata for Librarian 1.2.1

## Root cause

The search tokenizer is Unicode-category-aware, but continuous Chinese, Japanese, Thai-family, and related text is not reliably separated into linguistic words by spaces. Substring mode provides the deterministic fallback, but Librarian 1.2.0 rejected common one- and two-character terms. Repeated terms inside one continuous token were also counted only once.

The fix uses Unicode Script Extensions and Complex Context line-breaking properties instead of treating every non-Latin script alike. Arabic, Hebrew, Devanagari, Greek, Cyrillic, Hangul, and Latin keep their normal whole-word behavior; short substring exemptions remain narrow and explicit.

## Compatibility and rollout

- `whole_word` and `substring` remain explicit; Librarian does not silently rewrite caller-selected criteria.
- Simplified and Traditional Chinese are not conflated or transliterated.
- Search results now include `query.engine_version = 2`; deployments should flush old response caches and include the exported engine version in future cache namespaces.
- Robot can consume `requires_substring_matching()` in its follow-up Mini App fix after Librarian 1.2.1 is released.

## Validation

- `./scripts/run_release_gate.sh`
  - 138 deterministic tests passed; 12 intentionally live-only tests skipped
  - Ruff passed
  - Bandit passed
  - dependency audit reported no known vulnerabilities
  - sdist and wheel built successfully
  - Twine metadata checks passed
  - isolated wheel install/import/runtime smoke test passed
- checksum-verified full `cns` and `cnt` benchmark review
  - cold local index plus search: approximately 0.30 seconds
  - warm common Mandarin terms: approximately 42–112 ms median
  - one normalized full-translation index: approximately 23 MiB incremental RSS
  - pathological 64-term searches are rejected by the existing 50M work budget
