### PR TITLE
Stop a cold index build from consuming the caller's search deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,15 @@ query string; it no longer decides how a writing system should be read.
   character, so `all` matched inside `shall`.
 - Work is estimated from postings lengths. The previous estimator walked the
   whole vocabulary once per term and cost more than the search it guarded.
-- An index build no longer runs against the requesting call's deadline. A build
-  that timed out cached nothing, so the next request repeated it and failed the
-  same way.
+- An index build no longer runs against the requesting call's deadline, in
+  either direction. The build is bounded by `index_build_seconds` so it is
+  never abandoned part way, and the time it takes is returned to the
+  requesting call's budget so the caller that happens to trigger it does not
+  fail while every caller behind it succeeds. Waiting on another thread's
+  build is credited the same way.
+- Analysis classifies runs in one pass instead of examining each character,
+  roughly halving index construction, and ASCII text skips mark folding
+  entirely.
 - A query of nothing but combining marks is rejected rather than treated as an
   empty term.
 

--- a/src/getbible/search/analysis.py
+++ b/src/getbible/search/analysis.py
@@ -110,20 +110,26 @@ _LETTER: Final = regex.compile(r"[\p{L}\p{N}]")
 # Each class is intersected with letters and numbers so script-specific
 # punctuation — the Hebrew sof pasuq, the Devanagari danda, the ideographic
 # full stop — bounds a run instead of being absorbed into the word.
-_RUN_PATTERNS: Final = (
-    (
-        ScriptFamily.CONTINUOUS,
-        regex.compile(rf"(?V1)[[{_CONTINUOUS_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]+"),
-    ),
-    (
-        ScriptFamily.ABJAD,
-        regex.compile(rf"(?V1)[[{_ABJAD_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+"),
-    ),
-    (
-        ScriptFamily.BRAHMIC,
-        regex.compile(rf"(?V1)[[{_BRAHMIC_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+"),
-    ),
+#
+# One alternation finds every run in a single pass. Classifying character by
+# character cost a handful of regex calls per character, which on a whole
+# translation was seconds of index construction. The specific families come
+# first because Han and Hebrew letters are also ``\p{L}`` and would otherwise
+# be taken by the alphabetic branch.
+_RUN_SCANNER: Final = regex.compile(
+    rf"(?V1)"
+    rf"(?P<continuous>[[{_CONTINUOUS_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]+)"
+    rf"|(?P<abjad>[[{_ABJAD_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+)"
+    rf"|(?P<brahmic>[[{_BRAHMIC_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+)"
+    rf"|(?P<alphabetic>[{_WORD_START}][{_WORD_BODY}]*"
+    rf"(?:['’][{_WORD_START}][{_WORD_BODY}]*)*)"
 )
+_RUN_FAMILIES: Final = {
+    "continuous": ScriptFamily.CONTINUOUS,
+    "abjad": ScriptFamily.ABJAD,
+    "brahmic": ScriptFamily.BRAHMIC,
+    "alphabetic": ScriptFamily.ALPHABETIC,
+}
 
 # Precomposed letters that Unicode decomposition cannot reach. NFD turns "é"
 # into "e" plus a combining mark, but "đ" and "ø" are atomic code points, so a
@@ -184,6 +190,10 @@ def fold_marks(text: str) -> str:
     vowel pointing. Never applied to Brahmic or continuous text, where marks
     carry vowels that change the word.
     """
+    if text.isascii():
+        # ASCII carries no combining mark and no precomposed letter in the fold
+        # table, so an English corpus skips three Unicode passes per word.
+        return text
     decomposed = unicodedata.normalize("NFD", text.translate(_PRECOMPOSED_FOLD))
     stripped = "".join(
         character
@@ -217,44 +227,10 @@ def classify_text(text: str) -> ScriptFamily:
     return max(counts, key=lambda family: counts[family])
 
 
-def _family_of(character: str) -> ScriptFamily:
-    if _CONTINUOUS_CHAR.match(character):
-        return ScriptFamily.CONTINUOUS
-    if _ABJAD_CHAR.match(character):
-        return ScriptFamily.ABJAD
-    if _BRAHMIC_CHAR.match(character):
-        return ScriptFamily.BRAHMIC
-    return ScriptFamily.ALPHABETIC
-
-
 def _classify_runs(text: str) -> Iterator[tuple[ScriptFamily, str]]:
     """Split text into maximal single-family runs, skipping separators."""
-    position = 0
-    length = len(text)
-    while position < length:
-        character = text[position]
-        if not _LETTER.match(character) and not unicodedata.combining(character):
-            position += 1
-            continue
-        family = _family_of(character)
-        pattern = next(
-            (candidate for group, candidate in _RUN_PATTERNS if group is family),
-            None,
-        )
-        if pattern is None:
-            match = _WORD.match(text, position)
-            if match is None:
-                position += 1
-                continue
-            yield ScriptFamily.ALPHABETIC, match.group()
-            position = match.end()
-            continue
-        match = pattern.match(text, position)
-        if match is None:
-            position += 1
-            continue
-        yield family, match.group()
-        position = match.end()
+    for match in _RUN_SCANNER.finditer(text):
+        yield _RUN_FAMILIES[match.lastgroup], match.group()
 
 
 class Analyzer:

--- a/src/getbible/search/engine.py
+++ b/src/getbible/search/engine.py
@@ -10,6 +10,7 @@ and costs what the result set costs rather than what the vocabulary costs.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -210,9 +211,14 @@ class SearchEngine:
         # known without touching the index. Checking it first keeps a request
         # with an unusable budget from triggering an index build.
         budget.reserve(len(self.corpus.records) + criteria.limit * 8)
+        # Acquiring the index may build it, or wait on another thread building
+        # it. Either way the time belongs to the translation, not to this
+        # request, so it is returned to the budget before matching begins.
+        acquiring = time.monotonic()
         index = self.corpus.index(
             criteria.case_sensitive, criteria.fold_diacritics, self.limits
         )
+        budget.extend(time.monotonic() - acquiring)
         budget.reserve(self._estimate_work(index, units, exclusions, criteria))
 
         resolved = [self._resolve(index, unit, criteria, budget) for unit in units]

--- a/src/getbible/search/limits.py
+++ b/src/getbible/search/limits.py
@@ -111,6 +111,18 @@ class SearchBudget:
         """Add to the running total and fail once it passes the ceiling."""
         self.reserve(self.work_units + max(0, units))
 
+    def extend(self, seconds: float) -> None:
+        """Give back time spent on work that was not this request's own.
+
+        Building a shared index serves every later request. Whichever request
+        happens to trigger it must not lose its own deadline to it, or the
+        first caller after a restart fails while every caller behind them
+        succeeds — which is how a cold service looked broken.
+        """
+        if seconds > 0:
+            self.deadline += float(seconds)
+            self.started_at += float(seconds)
+
     def checkpoint(self, iteration: int = 0) -> None:
         if iteration % self.limits.deadline_check_interval == 0:
             self.check_deadline()

--- a/tests/test_search_sharing.py
+++ b/tests/test_search_sharing.py
@@ -2,12 +2,15 @@
 
 import tempfile
 import threading
+import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from getbible import GetBible, SearchBible
-from getbible.search import CorpusRegistry, shared_registry
+from getbible import GetBible, SearchBible, SearchDeadlineExceeded
+from getbible.search import CorpusRegistry, SearchBudget, SearchLimits, shared_registry
 from getbible.search.corpus import TranslationCorpus
+from getbible.search.engine import SearchEngine
 from getbible.translation_cache import TranslationSnapshot
 
 FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "multilingual_repository"
@@ -174,6 +177,76 @@ class TestSharedCorpusStillHonoursCriteria(unittest.TestCase):
         corpus = self.bible._search_corpus("multi")
 
         self.assertEqual(len(corpus.cache_info()["indexes"]), 3)
+
+
+class TestBuildTimeIsNotChargedToTheRequest(unittest.TestCase):
+    """A cold request must not die paying for work that serves everyone.
+
+    This reproduces the live-integration failure offline and deterministically.
+    The first search against a full translation builds its index; if that time
+    is charged to the requesting call's deadline, the first caller after a
+    restart fails while every caller behind them succeeds.
+    """
+
+    def _engine(self, limits: SearchLimits) -> SearchEngine:
+        from getbible.search.engine import SearchEngine
+
+        return SearchEngine(TranslationCorpus(_snapshot()), lambda name: None, limits)
+
+    def test_a_slow_index_build_does_not_consume_the_request_deadline(self) -> None:
+        from getbible.search import corpus as corpus_module
+
+        limits = SearchLimits(deadline_seconds=0.4, index_build_seconds=30.0)
+        engine = self._engine(limits)
+        original = corpus_module.build_index
+
+        def slow_build(*args: object, **kwargs: object) -> object:
+            time.sleep(0.9)  # more than twice the request deadline
+            return original(*args, **kwargs)
+
+        with patch.object(corpus_module, "build_index", slow_build):
+            hits, total = engine.search("faith", SearchBible())
+
+        self.assertGreater(total, 0)
+        self.assertTrue(hits)
+
+    def test_the_deadline_still_fires_for_the_request_s_own_work(self) -> None:
+        # Returning build time must not amount to switching the deadline off.
+        budget = SearchBudget(SearchLimits(deadline_seconds=0.05))
+        time.sleep(0.1)
+
+        with self.assertRaises(SearchDeadlineExceeded):
+            budget.check_deadline()
+
+    def test_extend_returns_exactly_the_time_it_is_given(self) -> None:
+        budget = SearchBudget(SearchLimits(deadline_seconds=1.0))
+        before = budget.deadline
+
+        budget.extend(2.5)
+        budget.extend(-1.0)  # never shortens
+
+        self.assertAlmostEqual(budget.deadline - before, 2.5, places=3)
+
+    def test_a_second_request_is_not_credited_for_a_build_it_did_not_do(
+        self,
+    ) -> None:
+        from getbible.search import corpus as corpus_module
+
+        limits = SearchLimits(deadline_seconds=0.4, index_build_seconds=30.0)
+        engine = self._engine(limits)
+        original = corpus_module.build_index
+        calls: list[int] = []
+
+        def counted_build(*args: object, **kwargs: object) -> object:
+            calls.append(1)
+            time.sleep(0.9)
+            return original(*args, **kwargs)
+
+        with patch.object(corpus_module, "build_index", counted_build):
+            engine.search("faith", SearchBible())
+            engine.search("hope", SearchBible())
+
+        self.assertEqual(len(calls), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the Live API Integration failure on master ([run 31319407167](https://github.com/getbible/librarian/actions/runs/31319407167)).

## The failure

```
ERROR: test_kjv_new_testament_scope
  engine.py:216  budget.reserve(self._estimate_work(...))
  limits.py:120  raise SearchDeadlineExceeded
SearchDeadlineExceeded: Search exceeded its 5-second deadline.
```

The first search against a full translation builds its index. That build was already bounded by `index_build_seconds`, so it is never abandoned part way — but the requesting call's budget was created *before* the build and its clock kept running through it. On a 31,102-verse translation the build alone can outlast the five-second request deadline, so the caller that triggered it died while every caller behind it, reusing the cached index, succeeded.

Tests run alphabetically, which is why `test_kjv_new_testament_scope` failed and `test_kjv_phrase_search_uses_verified_translation` passed: the first paid for the build, the second reused it. **Real phrase matching, SHA verification and results were all correct against live KJV** — only the cold-start accounting was wrong.

This is the same cold-start stall 2.0 set out to remove, in a form the earlier change did not reach.

## The fix

Acquiring an index either builds it or waits on another thread building it. Neither is the requesting call's own work, so both are credited back to its budget before matching begins. The deadline still governs everything the request does for itself.

Also halves the cost of that build: runs were classified a character at a time with several regular expressions per character; one alternation now finds every run in a single pass, and ASCII text skips mark folding entirely, which is most of an English translation. Measured on a representative English verse, projected over 31,102 verses: **3.8 s → 2.0 s**.

## Verification

The live suite only catches this when the runner is slow enough, so the regression is covered offline and deterministically:

- a build made slower than the request deadline must still return results
- a second request must not be credited for a build it did not perform
- extending must never shorten a deadline
- the deadline must still fire for the request's own work

End-to-end through the public `GetBible.search()` path, a **7-second cold build under the default 5-second deadline now succeeds**.

191 tests pass, ruff clean, local release gate exit 0.

## Still outstanding

The Live API Integration workflow is the proof for this one — please re-run it on the merge commit. My environment cannot reach `api.getbible.net`, so the golden corpora suite (`tests/test_golden_corpora.py`) has still never run against real translations; it skips without a tree present.