### PR TITLE
Fix cold-index deadlines and strengthen multilingual search coverage

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,12 +1,25 @@
 name: Live API Integration
 
 on:
+  pull_request:
+    branches: [master, staging]
+    paths:
+      - ".github/workflows/integration.yml"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "src/getbible/**"
+      - "tests/test_getbible.py"
+      - "tests/test_live_search.py"
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: live-api-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   live-api:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ query string; it no longer decides how a writing system should be read.
 - **The substring minimum applies only to space-delimited scripts.** Two
   characters of Han, Hangul, Thai, Hebrew, Arabic or Devanagari are an ordinary
   word, answered exactly by the index rather than by a scan.
-- `SEARCH_ENGINE_VERSION` is `3`. Downstream result caches keyed on it will
+- `SEARCH_ENGINE_VERSION` is `4`. Downstream result caches keyed on it will
   invalidate.
 - `getbible.search` is a package. All public names still import from `getbible`
   and from `getbible.search`.
@@ -58,9 +58,15 @@ query string; it no longer decides how a writing system should be read.
   character, so `all` matched inside `shall`.
 - Work is estimated from postings lengths. The previous estimator walked the
   whole vocabulary once per term and cost more than the search it guarded.
-- An index build no longer runs against the requesting call's deadline. A build
-  that timed out cached nothing, so the next request repeated it and failed the
-  same way.
+- An index build or lock wait no longer consumes the requesting call's
+  deadline. Only that shared interval is excluded; validation, filtering and
+  matching remain under one request-owned budget.
+- Script runs are classified in one pass, and ASCII mark folding bypasses
+  Unicode normalization, reducing cold English index construction without
+  changing token output.
+- Unicode join controls remain inside abjad and Brahmic words instead of
+  creating separate whole-word postings for the fragments on either side.
+- Isolated combining marks cannot create index terms or skew script reporting.
 - A query of nothing but combining marks is rejected rather than treated as an
   empty term.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ query string; it no longer decides how a writing system should be read.
 - Isolated combining marks cannot create index terms or skew script reporting.
 - A query of nothing but combining marks is rejected rather than treated as an
   empty term.
+- Empty optional language or encoding labels in published translation metadata
+  no longer prevent an otherwise valid corpus from loading.
 
 ### Deprecated
 

--- a/benchmarks/search_benchmark.py
+++ b/benchmarks/search_benchmark.py
@@ -49,6 +49,7 @@ SWEEP = (
     ("continuous", "thai", "\u0e1e\u0e23\u0e30\u0e40\u0e08\u0e49\u0e32"),
     ("abjad", "modernhebrew", "\u05d0\u05dc\u05d4\u05d9\u05dd"),
     ("abjad", "arabicsv", "\u0627\u0644\u0644\u0647"),
+    ("brahmic", "mal1910", "\u0d26\u0d48\u0d35\u0d02"),
 )
 
 

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -212,7 +212,7 @@ matches
   score, occurrences, terms
 ```
 
-`engine_version` is `3`. It moves whenever matching semantics change, so a
+`engine_version` is `4`. It moves whenever matching semantics change, so a
 downstream result cache can be invalidated without waiting for a translation SHA
 to change. **Key your response cache on it.**
 
@@ -264,7 +264,7 @@ in a mixed query.
 | Continuous scripts under default criteria | returned nothing | return the verses |
 | `diacritics` default | `sensitive` | `fold` |
 | Substring floor | all scripts | space-delimited scripts only |
-| `engine_version` | `2` | `3` |
+| `engine_version` | `2` | `4` |
 | Abjad with attached particle | missed | reachable by stem |
 
 Default searches return **more** than they did. If your application asserted a
@@ -277,7 +277,7 @@ is there to key that on.
   of `diacritics` (string).
 - `warm_translation()` takes `diacritics="fold"` by default and returns an
   `analysis` block.
-- `SEARCH_ENGINE_VERSION` is `3`.
+- `SEARCH_ENGINE_VERSION` is `4`.
 - `getbible.search` is a package. Every public name still imports from
   `getbible` and from `getbible.search`; the internal `_Matcher` class is gone.
 

--- a/src/getbible/search/analysis.py
+++ b/src/getbible/search/analysis.py
@@ -97,9 +97,6 @@ _BRAHMIC_CLASS: Final = (
     r"\p{Script_Extensions=Sinhala}"
 )
 
-_CONTINUOUS_CHAR: Final = regex.compile(rf"[{_CONTINUOUS_CLASS}]")
-_ABJAD_CHAR: Final = regex.compile(rf"[{_ABJAD_CLASS}]")
-_BRAHMIC_CHAR: Final = regex.compile(rf"[{_BRAHMIC_CLASS}]")
 _LETTER: Final = regex.compile(r"[\p{L}\p{N}]")
 
 # A run is a maximal stretch of one family. Splitting text into runs is what
@@ -110,20 +107,26 @@ _LETTER: Final = regex.compile(r"[\p{L}\p{N}]")
 # Each class is intersected with letters and numbers so script-specific
 # punctuation — the Hebrew sof pasuq, the Devanagari danda, the ideographic
 # full stop — bounds a run instead of being absorbed into the word.
-_RUN_PATTERNS: Final = (
-    (
-        ScriptFamily.CONTINUOUS,
-        regex.compile(rf"(?V1)[[{_CONTINUOUS_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]+"),
-    ),
-    (
-        ScriptFamily.ABJAD,
-        regex.compile(rf"(?V1)[[{_ABJAD_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+"),
-    ),
-    (
-        ScriptFamily.BRAHMIC,
-        regex.compile(rf"(?V1)[[{_BRAHMIC_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]‌‍]+"),
-    ),
+#
+# One alternation finds every run in a single pass. The specific families come
+# first because their letters also satisfy the generic alphabetic branch.
+_RUN_SCANNER: Final = regex.compile(
+    rf"(?V1)"
+    rf"(?P<continuous>[[{_CONTINUOUS_CLASS}]&&[\p{{L}}\p{{N}}]]"
+    rf"[[{_CONTINUOUS_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]*)"
+    rf"|(?P<abjad>[[{_ABJAD_CLASS}]&&[\p{{L}}\p{{N}}]]"
+    rf"(?:[[{_ABJAD_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]|[‌‍])*)"
+    rf"|(?P<brahmic>[[{_BRAHMIC_CLASS}]&&[\p{{L}}\p{{N}}]]"
+    rf"(?:[[{_BRAHMIC_CLASS}]&&[\p{{L}}\p{{N}}\p{{M}}]]|[‌‍])*)"
+    rf"|(?P<alphabetic>[{_WORD_START}][{_WORD_BODY}]*"
+    rf"(?:['’][{_WORD_START}][{_WORD_BODY}]*)*)"
 )
+_RUN_FAMILIES: Final = {
+    "continuous": ScriptFamily.CONTINUOUS,
+    "abjad": ScriptFamily.ABJAD,
+    "brahmic": ScriptFamily.BRAHMIC,
+    "alphabetic": ScriptFamily.ALPHABETIC,
+}
 
 # Precomposed letters that Unicode decomposition cannot reach. NFD turns "é"
 # into "e" plus a combining mark, but "đ" and "ø" are atomic code points, so a
@@ -184,6 +187,8 @@ def fold_marks(text: str) -> str:
     vowel pointing. Never applied to Brahmic or continuous text, where marks
     carry vowels that change the word.
     """
+    if text.isascii():
+        return text
     decomposed = unicodedata.normalize("NFD", text.translate(_PRECOMPOSED_FOLD))
     stripped = "".join(
         character
@@ -217,44 +222,10 @@ def classify_text(text: str) -> ScriptFamily:
     return max(counts, key=lambda family: counts[family])
 
 
-def _family_of(character: str) -> ScriptFamily:
-    if _CONTINUOUS_CHAR.match(character):
-        return ScriptFamily.CONTINUOUS
-    if _ABJAD_CHAR.match(character):
-        return ScriptFamily.ABJAD
-    if _BRAHMIC_CHAR.match(character):
-        return ScriptFamily.BRAHMIC
-    return ScriptFamily.ALPHABETIC
-
-
 def _classify_runs(text: str) -> Iterator[tuple[ScriptFamily, str]]:
     """Split text into maximal single-family runs, skipping separators."""
-    position = 0
-    length = len(text)
-    while position < length:
-        character = text[position]
-        if not _LETTER.match(character) and not unicodedata.combining(character):
-            position += 1
-            continue
-        family = _family_of(character)
-        pattern = next(
-            (candidate for group, candidate in _RUN_PATTERNS if group is family),
-            None,
-        )
-        if pattern is None:
-            match = _WORD.match(text, position)
-            if match is None:
-                position += 1
-                continue
-            yield ScriptFamily.ALPHABETIC, match.group()
-            position = match.end()
-            continue
-        match = pattern.match(text, position)
-        if match is None:
-            position += 1
-            continue
-        yield family, match.group()
-        position = match.end()
+    for match in _RUN_SCANNER.finditer(text):
+        yield _RUN_FAMILIES[match.lastgroup], match.group()
 
 
 class Analyzer:

--- a/src/getbible/search/engine.py
+++ b/src/getbible/search/engine.py
@@ -203,6 +203,9 @@ class SearchEngine:
         query: str,
         criteria: SearchBible,
     ) -> tuple[list[SearchHit], int]:
+        # Validate the corpus-independent request before touching the index.
+        # The preliminary budget also rejects an impossible corpus scan before
+        # an expensive index build starts.
         budget = SearchBudget(self.limits)
         _, units, exclusions = validate_search_request(query, criteria, self.limits)
         book_filter = self._book_filter(criteria)
@@ -213,6 +216,11 @@ class SearchEngine:
         index = self.corpus.index(
             criteria.case_sensitive, criteria.fold_diacritics, self.limits
         )
+        # Index construction has its own bounded build window and produces a
+        # shared asset for later requests. Start the per-request execution
+        # deadline only after that one-time work has completed.
+        budget = SearchBudget(self.limits)
+        budget.reserve(len(self.corpus.records) + criteria.limit * 8)
         budget.reserve(self._estimate_work(index, units, exclusions, criteria))
 
         resolved = [self._resolve(index, unit, criteria, budget) for unit in units]

--- a/src/getbible/search/engine.py
+++ b/src/getbible/search/engine.py
@@ -10,6 +10,7 @@ and costs what the result set costs rather than what the vocabulary costs.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -31,7 +32,7 @@ __all__ = [
 
 #: Bumped whenever matching semantics change, so a downstream result cache can
 #: be invalidated without waiting for a translation SHA to move.
-SEARCH_ENGINE_VERSION = 3
+SEARCH_ENGINE_VERSION = 4
 
 
 @dataclass(frozen=True, slots=True)
@@ -203,9 +204,6 @@ class SearchEngine:
         query: str,
         criteria: SearchBible,
     ) -> tuple[list[SearchHit], int]:
-        # Validate the corpus-independent request before touching the index.
-        # The preliminary budget also rejects an impossible corpus scan before
-        # an expensive index build starts.
         budget = SearchBudget(self.limits)
         _, units, exclusions = validate_search_request(query, criteria, self.limits)
         book_filter = self._book_filter(criteria)
@@ -213,14 +211,14 @@ class SearchEngine:
         # known without touching the index. Checking it first keeps a request
         # with an unusable budget from triggering an index build.
         budget.reserve(len(self.corpus.records) + criteria.limit * 8)
+        acquiring = time.monotonic()
         index = self.corpus.index(
             criteria.case_sensitive, criteria.fold_diacritics, self.limits
         )
-        # Index construction has its own bounded build window and produces a
-        # shared asset for later requests. Start the per-request execution
-        # deadline only after that one-time work has completed.
-        budget = SearchBudget(self.limits)
-        budget.reserve(len(self.corpus.records) + criteria.limit * 8)
+        # Building an index, or waiting for another request to build it, is
+        # separately bounded shared work. Exclude only that interval while
+        # retaining all request-owned validation and filtering time.
+        budget.extend(time.monotonic() - acquiring)
         budget.reserve(self._estimate_work(index, units, exclusions, criteria))
 
         resolved = [self._resolve(index, unit, criteria, budget) for unit in units]

--- a/src/getbible/search/limits.py
+++ b/src/getbible/search/limits.py
@@ -111,6 +111,18 @@ class SearchBudget:
         """Add to the running total and fail once it passes the ceiling."""
         self.reserve(self.work_units + max(0, units))
 
+    def extend(self, seconds: float) -> None:
+        """Exclude shared work from this request's elapsed-time budget.
+
+        Index construction and lock waiting serve the translation rather than
+        one request. Shifting both timestamps preserves the original deadline
+        for request-owned work and keeps elapsed telemetry accurate.
+        """
+        if seconds > 0:
+            elapsed = float(seconds)
+            self.deadline += elapsed
+            self.started_at += elapsed
+
     def checkpoint(self, iteration: int = 0) -> None:
         if iteration % self.limits.deadline_check_interval == 0:
             self.check_deadline()

--- a/src/getbible/translation_cache.py
+++ b/src/getbible/translation_cache.py
@@ -79,6 +79,7 @@ class TranslationCache:
         "direction",
         "encoding",
     )
+    OPTIONAL_BOOK_INDEX_METADATA = frozenset({"language", "encoding"})
 
     def __init__(
         self,
@@ -623,7 +624,11 @@ class TranslationCache:
         metadata: list[tuple[str, str]] = []
         for field in cls.BOOK_INDEX_METADATA:
             value = source.get(field)
-            if not isinstance(value, str) or not value or len(value) > cls.MAX_NAME_LENGTH:
+            if (
+                not isinstance(value, str)
+                or len(value) > cls.MAX_NAME_LENGTH
+                or (not value and field not in cls.OPTIONAL_BOOK_INDEX_METADATA)
+            ):
                 raise CacheIntegrityError(
                     f"Books index contains an invalid {field!r} field."
                 )

--- a/tests/test_live_search.py
+++ b/tests/test_live_search.py
@@ -68,6 +68,28 @@ class TestLiveSearch(unittest.TestCase):
 
         self.assertGreater(response["query"]["total"], 0)
         self.assertEqual(response["query"]["analysis"], {"script": "abjad"})
+        self.assertTrue(
+            any(
+                match["book_nr"] == 1
+                and match["chapter"] == 24
+                and match["verse"] == 7
+                for match in response["matches"]
+            )
+        )
+
+    def test_malayalam_brahmic_search(self):
+        response = self.bible.search("ദൈവം", "mal1910")
+
+        self.assertGreater(response["query"]["total"], 0)
+        self.assertEqual(response["query"]["analysis"], {"script": "brahmic"})
+        self.assertTrue(
+            any(
+                match["book_nr"] == 1
+                and match["chapter"] == 1
+                and match["verse"] == 1
+                for match in response["matches"]
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_live_search.py
+++ b/tests/test_live_search.py
@@ -35,6 +35,40 @@ class TestLiveSearch(unittest.TestCase):
             all(match["book_nr"] >= 40 for match in response["matches"])
         )
 
+    def test_chinese_continuous_script_search(self):
+        response = self.bible.search("神爱世人", "cus")
+
+        self.assertGreater(response["query"]["total"], 0)
+        self.assertEqual(response["query"]["analysis"], {"script": "continuous"})
+        self.assertTrue(
+            any(
+                match["book_nr"] == 43
+                and match["chapter"] == 3
+                and match["verse"] == 16
+                for match in response["matches"]
+            )
+        )
+
+    def test_hebrew_abjad_search(self):
+        response = self.bible.search("בראשית", "aleppo")
+
+        self.assertGreater(response["query"]["total"], 0)
+        self.assertEqual(response["query"]["analysis"], {"script": "abjad"})
+        self.assertTrue(
+            any(
+                match["book_nr"] == 1
+                and match["chapter"] == 1
+                and match["verse"] == 1
+                for match in response["matches"]
+            )
+        )
+
+    def test_arabic_abjad_search(self):
+        response = self.bible.search("الرب", "arabicsv")
+
+        self.assertGreater(response["query"]["total"], 0)
+        self.assertEqual(response["query"]["analysis"], {"script": "abjad"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_multilingual_search.py
+++ b/tests/test_multilingual_search.py
@@ -156,6 +156,12 @@ class TestBrahmicScripts(TestMultilingualSearch):
         self.assertEqual(self._verse_numbers(self._search("می‌رود")), [21])
         self.assertEqual(self._verse_numbers(self._search("क्‍ष")), [22])
 
+        # The controls join each written word. Its fragments must not become
+        # independent whole-word postings merely because both sides analyse
+        # text using the same rules.
+        self.assertNotIn(21, self._verse_numbers(self._search("می")))
+        self.assertNotIn(22, self._verse_numbers(self._search("क्")))
+
 
 class TestMixedScripts(TestMultilingualSearch):
     def test_each_part_of_a_mixed_query_keeps_its_own_rules(self) -> None:
@@ -193,7 +199,7 @@ class TestResponseContract(TestMultilingualSearch):
     def test_engine_version_marks_the_matching_change(self) -> None:
         # Downstream result caches key on this, so it must move when matching
         # semantics change without a translation SHA changing.
-        self.assertEqual(self._search("神")["query"]["engine_version"], 3)
+        self.assertEqual(self._search("神")["query"]["engine_version"], 4)
 
     def test_the_response_reports_how_the_translation_was_read(self) -> None:
         self.assertEqual(

--- a/tests/test_multilingual_search_limits.py
+++ b/tests/test_multilingual_search_limits.py
@@ -98,7 +98,7 @@ class TestMultilingualSearchLimits(unittest.TestCase):
         # 1.x asked applications to detect continuous scripts and switch to
         # substring. The engine derives that itself now, so the helper reports
         # that no caller-side change is required, for every script.
-        self.assertEqual(SEARCH_ENGINE_VERSION, 3)
+        self.assertEqual(SEARCH_ENGINE_VERSION, 4)
 
         for script, query in {
             "Han": "神",

--- a/tests/test_release_hardening.py
+++ b/tests/test_release_hardening.py
@@ -90,6 +90,37 @@ class ReleaseHardeningTestCase(unittest.TestCase):
         metadata = tuple(self.cache.rglob("test.metadata.json"))
         self.assertEqual(metadata, ())
 
+    def test_empty_optional_books_metadata_matches_published_corpora(self) -> None:
+        translation_path = self.repository / "v2" / "test.json"
+        translation = json.loads(translation_path.read_text(encoding="utf-8"))
+        translation["language"] = ""
+        translation["encoding"] = ""
+        translation_path.write_text(json.dumps(translation), encoding="utf-8")
+
+        books_path = self.repository / "v2" / "test" / "books.json"
+        books = json.loads(books_path.read_text(encoding="utf-8"))
+        for book in books.values():
+            book["language"] = ""
+            book["encoding"] = ""
+        books_path.write_text(json.dumps(books), encoding="utf-8")
+
+        self.assertEqual(self._bible().search("faith", "test")["query"]["total"], 3)
+
+    def test_empty_required_books_metadata_is_rejected(self) -> None:
+        translation_path = self.repository / "v2" / "test.json"
+        translation = json.loads(translation_path.read_text(encoding="utf-8"))
+        translation["lang"] = ""
+        translation_path.write_text(json.dumps(translation), encoding="utf-8")
+
+        books_path = self.repository / "v2" / "test" / "books.json"
+        books = json.loads(books_path.read_text(encoding="utf-8"))
+        for book in books.values():
+            book["lang"] = ""
+        books_path.write_text(json.dumps(books), encoding="utf-8")
+
+        with self.assertRaisesRegex(CacheIntegrityError, "invalid 'lang' field"):
+            self._bible().search("faith", "test")
+
     def test_validated_payload_is_content_addressed_and_versioned(self) -> None:
         sha = self._publish_translation_sha()
         bible = self._bible(require_checksums=True)

--- a/tests/test_search_analysis.py
+++ b/tests/test_search_analysis.py
@@ -8,6 +8,7 @@ made to fit the implementation.
 import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from getbible.search.analysis import (
     Analyzer,
@@ -15,6 +16,7 @@ from getbible.search.analysis import (
     classify_text,
     fold_marks,
     normalize_book_name,
+    script_census,
 )
 from getbible.search.index import build_index, chain_matches, merge_verses
 
@@ -115,6 +117,36 @@ class TestAnalyzer(unittest.TestCase):
         self.assertIn("예수", terms)        # Hangul becomes n-grams
         self.assertNotIn("jesus耶稣", terms)
 
+    def test_single_pass_scanner_preserves_every_family_boundary(self) -> None:
+        self.assertEqual(
+            self.analyzer.runs("Faith’s—神爱世人—בְּרֵאשִׁית׃—पृथ्वी"),
+            [
+                (ScriptFamily.ALPHABETIC, "faith’s"),
+                (ScriptFamily.CONTINUOUS, "神爱世人"),
+                (ScriptFamily.ABJAD, "בראשית"),
+                (ScriptFamily.BRAHMIC, "पृथ्वी"),
+            ],
+        )
+
+    def test_join_controls_remain_inside_abjad_and_brahmic_words(self) -> None:
+        self.assertEqual(
+            self.analyzer.runs("می‌رود"),
+            [(ScriptFamily.ABJAD, "می‌رود")],
+        )
+        self.assertEqual(
+            self.analyzer.runs("क्‍ष"),
+            [(ScriptFamily.BRAHMIC, "क्‍ष")],
+        )
+
+    def test_isolated_marks_do_not_create_runs_or_skew_script_census(self) -> None:
+        isolated_marks = "َ ा ่ ◌́".replace("◌", "")
+
+        self.assertEqual(self.analyzer.tokens(isolated_marks), [])
+        self.assertEqual(
+            script_census([isolated_marks]),
+            dict.fromkeys(ScriptFamily, 0),
+        )
+
     def test_accents_fold_so_unaccented_queries_reach_accented_text(self) -> None:
         self.assertEqual(self._terms("λόγος"), self._terms("λογος"))
         self.assertEqual(self._terms("Ðức Chúa Trời"), self._terms("Duc Chua Troi"))
@@ -152,6 +184,12 @@ class TestAnalyzer(unittest.TestCase):
 
     def test_fold_marks_reaches_precomposed_letters(self) -> None:
         self.assertEqual(fold_marks("Đường ø ł"), "Duong o l")
+
+    def test_ascii_mark_folding_bypasses_unicode_normalization(self) -> None:
+        with patch("getbible.search.analysis.unicodedata.normalize") as normalize:
+            self.assertEqual(fold_marks("faith's 123"), "faith's 123")
+
+        normalize.assert_not_called()
 
     def test_book_names_fold_for_lookup(self) -> None:
         self.assertEqual(normalize_book_name("1 Cor."), "1cor")

--- a/tests/test_search_sharing.py
+++ b/tests/test_search_sharing.py
@@ -2,13 +2,15 @@
 
 import tempfile
 import threading
-import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest.mock import patch
 
-from getbible import GetBible, SearchBible
+from getbible import GetBible, SearchBible, SearchDeadlineExceeded
 from getbible.search import (
     CorpusRegistry,
+    SearchBudget,
     SearchEngine,
     SearchLimits,
     shared_registry,
@@ -17,6 +19,40 @@ from getbible.search.corpus import TranslationCorpus
 from getbible.translation_cache import TranslationSnapshot
 
 FIXTURE_REPOSITORY = Path(__file__).parent / "fixtures" / "multilingual_repository"
+
+
+class _FakeClock:
+    """Thread-safe monotonic clock advanced explicitly by each test phase."""
+
+    def __init__(self, value: float = 0.0) -> None:
+        self._lock = threading.Lock()
+        self._value = value
+
+    def __call__(self) -> float:
+        with self._lock:
+            return self._value
+
+    def advance(self, seconds: float) -> None:
+        with self._lock:
+            self._value += seconds
+
+
+class _ObservedLock:
+    """Lock that records when a second caller has to wait for its holder."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.waiting = threading.Event()
+
+    def __enter__(self) -> "_ObservedLock":
+        if not self._lock.acquire(blocking=False):
+            self.waiting.set()
+            if not self._lock.acquire(timeout=2.0):
+                raise TimeoutError("Timed out waiting for the test index lock.")
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._lock.release()
 
 
 def _snapshot(sha: str = "sha-one") -> TranslationSnapshot:
@@ -142,23 +178,6 @@ class TestIndexConstruction(unittest.TestCase):
         self.assertEqual(builds, 1)
         self.assertEqual(len(indexes), 8)
 
-    def test_an_index_build_is_not_charged_to_the_request_deadline(self) -> None:
-        # deadline_seconds governs one request; index_build_seconds governs a
-        # build that every later request benefits from.
-        class SlowIndexCorpus(TranslationCorpus):
-            def index(self, *args, **kwargs):
-                time.sleep(0.02)
-                return super().index(*args, **kwargs)
-
-        limits = SearchLimits(deadline_seconds=0.01, index_build_seconds=60.0)
-        corpus = SlowIndexCorpus(_snapshot())
-        engine = SearchEngine(corpus, lambda name: 1 if name == "Book" else None, limits)
-
-        hits, total = engine.search("faith", SearchBible())
-
-        self.assertEqual(total, 39)
-        self.assertEqual(len(hits), 39)
-
     def test_a_built_index_is_published_before_the_lock_is_released(self) -> None:
         corpus = TranslationCorpus(_snapshot())
 
@@ -166,6 +185,167 @@ class TestIndexConstruction(unittest.TestCase):
 
         self.assertIs(corpus.index(), first)
         self.assertEqual(len(corpus.cache_info()["indexes"]), 1)
+
+
+class TestSearchDeadlineAccounting(unittest.TestCase):
+    def _engine(
+        self,
+        corpus: TranslationCorpus,
+        limits: SearchLimits,
+    ) -> SearchEngine:
+        return SearchEngine(
+            corpus,
+            lambda name: 1 if name == "Book" else None,
+            limits,
+        )
+
+    def test_cold_index_time_is_excluded_end_to_end(self) -> None:
+        from getbible.search import corpus as corpus_module
+
+        clock = _FakeClock()
+        limits = SearchLimits(deadline_seconds=5.0, index_build_seconds=60.0)
+        corpus = TranslationCorpus(_snapshot())
+        engine = self._engine(corpus, limits)
+        original = corpus_module.build_index
+        build_calls = 0
+
+        def delayed_build(*args: object, **kwargs: object) -> object:
+            nonlocal build_calls
+            build_calls += 1
+            clock.advance(10.0)
+            return original(*args, **kwargs)
+
+        with (
+            patch("getbible.search.limits.time.monotonic", clock),
+            patch.object(corpus_module, "build_index", delayed_build),
+        ):
+            hits, total = engine.search("faith", SearchBible())
+
+        self.assertEqual(build_calls, 1)
+        self.assertEqual(total, 39)
+        self.assertEqual(len(hits), 39)
+        self.assertEqual(engine.execution_info["elapsed_seconds"], 0.0)
+
+    def test_warm_index_does_not_reset_request_owned_work(self) -> None:
+        clock = _FakeClock()
+        limits = SearchLimits(deadline_seconds=5.0, index_build_seconds=60.0)
+        corpus = TranslationCorpus(_snapshot())
+        corpus.index(False, True, limits)
+        engine = self._engine(corpus, limits)
+        original_book_filter = engine._book_filter
+        original_resolve = engine._resolve
+
+        def delayed_book_filter(criteria: SearchBible) -> frozenset[int]:
+            clock.advance(3.0)
+            return original_book_filter(criteria)
+
+        def delayed_resolve(*args: object, **kwargs: object) -> object:
+            clock.advance(3.0)
+            return original_resolve(*args, **kwargs)
+
+        with (
+            patch("getbible.search.limits.time.monotonic", clock),
+            patch.object(engine, "_book_filter", side_effect=delayed_book_filter),
+            patch.object(engine, "_resolve", side_effect=delayed_resolve),
+            self.assertRaises(SearchDeadlineExceeded),
+        ):
+            engine.search("faith", SearchBible())
+
+    def test_concurrent_builder_and_waiter_keep_their_request_deadlines(
+        self,
+    ) -> None:
+        from getbible.search import corpus as corpus_module
+
+        clock = _FakeClock()
+        limits = SearchLimits(deadline_seconds=5.0, index_build_seconds=60.0)
+        corpus = TranslationCorpus(_snapshot())
+        index_lock = _ObservedLock()
+        corpus._index_locks[(False, True)] = index_lock
+        original = corpus_module.build_index
+        build_started = threading.Event()
+        release_build = threading.Event()
+        build_calls = 0
+        build_guard = threading.Lock()
+
+        def blocked_build(*args: object, **kwargs: object) -> object:
+            nonlocal build_calls
+            with build_guard:
+                build_calls += 1
+            build_started.set()
+            if not release_build.wait(timeout=2.0):
+                raise TimeoutError("Timed out waiting to release the test build.")
+            clock.advance(10.0)
+            return original(*args, **kwargs)
+
+        def search() -> tuple[int, int]:
+            hits, total = self._engine(corpus, limits).search(
+                "faith", SearchBible()
+            )
+            return len(hits), total
+
+        with (
+            patch("getbible.search.limits.time.monotonic", clock),
+            patch.object(corpus_module, "build_index", blocked_build),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            futures = [executor.submit(search) for _ in range(2)]
+            started = build_started.wait(timeout=2.0)
+            waiting = index_lock.waiting.wait(timeout=2.0) if started else False
+            release_build.set()
+            results = [future.result(timeout=2.0) for future in futures]
+
+        self.assertTrue(started)
+        self.assertTrue(waiting)
+        self.assertEqual(build_calls, 1)
+        self.assertEqual(results, [(39, 39), (39, 39)])
+        self.assertEqual(len(corpus.cache_info()["indexes"]), 1)
+
+    def test_index_build_limit_remains_independent(self) -> None:
+        from getbible.search import corpus as corpus_module
+
+        clock = _FakeClock()
+        limits = SearchLimits(deadline_seconds=5.0, index_build_seconds=1.0)
+        corpus = TranslationCorpus(_snapshot())
+        engine = self._engine(corpus, limits)
+
+        def overdue_build(
+            texts: object,
+            analyzer: object,
+            checkpoint: object,
+        ) -> object:
+            clock.advance(2.0)
+            checkpoint(0)
+            self.fail("The overdue index build should have been stopped.")
+
+        with (
+            patch("getbible.search.limits.time.monotonic", clock),
+            patch.object(corpus_module, "build_index", overdue_build),
+            self.assertRaisesRegex(TimeoutError, "Index construction exceeded"),
+        ):
+            engine.search("faith", SearchBible())
+
+        self.assertEqual(corpus.cache_info()["indexes"], [])
+
+    def test_extending_a_budget_preserves_own_work_and_telemetry(self) -> None:
+        clock = _FakeClock(100.0)
+        limits = SearchLimits(deadline_seconds=5.0)
+
+        with patch("getbible.search.limits.time.monotonic", clock):
+            budget = SearchBudget(limits)
+            clock.advance(2.5)
+            budget.extend(2.5)
+
+            self.assertEqual(budget.started_at, 102.5)
+            self.assertEqual(budget.deadline, 107.5)
+            self.assertEqual(budget.elapsed_seconds, 0.0)
+
+            budget.extend(0.0)
+            budget.extend(-1.0)
+            self.assertEqual(budget.started_at, 102.5)
+            self.assertEqual(budget.deadline, 107.5)
+
+            clock.advance(1.25)
+            self.assertEqual(budget.elapsed_seconds, 1.25)
 
 
 class TestSharedCorpusStillHonoursCriteria(unittest.TestCase):

--- a/tests/test_search_sharing.py
+++ b/tests/test_search_sharing.py
@@ -2,11 +2,17 @@
 
 import tempfile
 import threading
+import time
 import unittest
 from pathlib import Path
 
 from getbible import GetBible, SearchBible
-from getbible.search import CorpusRegistry, shared_registry
+from getbible.search import (
+    CorpusRegistry,
+    SearchEngine,
+    SearchLimits,
+    shared_registry,
+)
 from getbible.search.corpus import TranslationCorpus
 from getbible.translation_cache import TranslationSnapshot
 
@@ -139,14 +145,19 @@ class TestIndexConstruction(unittest.TestCase):
     def test_an_index_build_is_not_charged_to_the_request_deadline(self) -> None:
         # deadline_seconds governs one request; index_build_seconds governs a
         # build that every later request benefits from.
-        from getbible.search import SearchLimits
+        class SlowIndexCorpus(TranslationCorpus):
+            def index(self, *args, **kwargs):
+                time.sleep(0.02)
+                return super().index(*args, **kwargs)
 
-        limits = SearchLimits(deadline_seconds=0.001, index_build_seconds=60.0)
-        corpus = TranslationCorpus(_snapshot())
+        limits = SearchLimits(deadline_seconds=0.01, index_build_seconds=60.0)
+        corpus = SlowIndexCorpus(_snapshot())
+        engine = SearchEngine(corpus, lambda name: 1 if name == "Book" else None, limits)
 
-        index = corpus.index(False, True, limits)
+        hits, total = engine.search("faith", SearchBible())
 
-        self.assertGreater(len(index.postings), 0)
+        self.assertEqual(total, 39)
+        self.assertEqual(len(hits), 39)
 
     def test_a_built_index_is_published_before_the_lock_is_released(self) -> None:
         corpus = TranslationCorpus(_snapshot())


### PR DESCRIPTION
## What changed

- exclude exactly the time spent building or waiting for a shared search index while keeping validation, filtering, and matching under one request-owned deadline
- retain the pre-index work-floor rejection so abusive searches fail before index construction
- classify script runs in one pass and bypass Unicode normalization for ASCII mark folding
- keep ZWJ/ZWNJ inside abjad and Brahmic words and reject isolated marks as index terms
- add deterministic fake-clock coverage for cold, warm, concurrent builder/waiter, build-timeout, and elapsed-telemetry behavior
- retain live Chinese and Hebrew coverage, strengthen Arabic with a canonical reference, and add Malayalam Brahmic coverage
- accept blank optional `language` and `encoding` labels used by published corpora while continuing to reject blank required identifiers
- run the Live API Integration workflow on search-related pull requests
- add Malayalam to the writing-system benchmark sweep and bump `SEARCH_ENGINE_VERSION` to 4 for the matching-semantic correction

## Root cause

A request budget started before lazy index acquisition, so a cold KJV index build could consume the five-second request deadline even though index construction is separately bounded and shared. The previous PR revision reset the budget after acquisition, but that also forgave request-owned pre-index work. This revision excludes only the shared build/wait interval.

The first Malayalam live run also exposed an existing metadata compatibility defect: the published `mal1910` corpus has an empty descriptive `language` label, which the cache integrity check incorrectly treated as a required identifier. The validator now distinguishes optional labels from required metadata and has regressions for both paths.

## Validation

- local release gate passed
- 201 deterministic tests passed; 21 opt-in live/golden tests skipped as designed
- deadline/concurrency regression group passed 25 consecutive runs
- Ruff, Bandit, pip-audit, compile, build, Twine, and isolated-wheel verification passed
- direct current API corpus checks passed for KJV, Chinese `cus`, Hebrew `aleppo`, Arabic `arabicsv`, and Malayalam `mal1910`
- GitHub CI and Live API Integration rerun on commit `06461a4`
